### PR TITLE
Updates

### DIFF
--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -130,17 +130,20 @@ func GenericErr(e error) Fn {
 	}
 }
 
-// Param adds they query parameter to the response's URL.
+// Params adds the query parameters to the response's URL.
+// Params appends to rather than overwrite other query parameters.
 //
 // Used with Responder.Redirect.
-func Param(key, val string) Fn {
+func Params(pairs map[string]string) Fn {
 	return func(_ Responder, r *Response) error {
 		if r.url == nil {
 			return fmt.Errorf("%w: Url() has not been called", ErrMissingData)
 		}
 
 		q := r.url.Query()
-		q.Add(key, val)
+		for k, v := range pairs {
+			q.Add(k, v)
+		}
 		r.url.RawQuery = q.Encode()
 		return nil
 	}

--- a/http/resp/response_test.go
+++ b/http/resp/response_test.go
@@ -287,7 +287,7 @@ func TestGenericErr(t *testing.T) {
 	}
 }
 
-func TestParam(t *testing.T) {
+func TestParams(t *testing.T) {
 	goodURL, _ := url.Parse("http://example.com")
 
 	testKey, testValue := "test", "params"
@@ -299,13 +299,13 @@ func TestParam(t *testing.T) {
 	tcs := []struct {
 		name   string
 		r      *Response
-		input  [2]string
+		input  map[string]string
 		assert func(*testing.T, *Response, error)
 	}{
 		{
 			name:  "No-Url",
 			r:     &Response{},
-			input: [2]string{"go", "rocks"},
+			input: map[string]string{"go": "rocks"},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.ErrorIs(t, err, ErrMissingData)
 			},
@@ -313,7 +313,7 @@ func TestParam(t *testing.T) {
 		{
 			name:  "Url",
 			r:     &Response{url: goodURL},
-			input: [2]string{"go", "rocks"},
+			input: map[string]string{"go": "rocks"},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
 
@@ -324,7 +324,7 @@ func TestParam(t *testing.T) {
 		{
 			name:  "With-Params",
 			r:     &Response{url: withParams},
-			input: [2]string{"go", "rocks"},
+			input: map[string]string{"go": "rocks"},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
 				require.Equal(t, "rocks", r.url.Query().Get("go"))
@@ -339,7 +339,7 @@ func TestParam(t *testing.T) {
 			d := Responder{}
 
 			// Act
-			err := Param(tc.input[0], tc.input[1])(d, tc.r)
+			err := Params(tc.input)(d, tc.r)
 
 			// Assert
 			tc.assert(t, tc.r, err)
@@ -350,14 +350,13 @@ func TestParam(t *testing.T) {
 		// Arrange
 		r := &Response{url: goodURL}
 		d := Responder{}
-		ins := [][2]string{{"go", "rocks"}, {"fun", "tests"}}
-		for _, in := range ins {
-			// Act
-			err := Param(in[0], in[1])(d, r)
+		ins := map[string]string{"go": "rocks", "fun": "tests"}
 
-			// Assert
-			require.Nil(t, err)
-		}
+		// Act
+		err := Params(ins)(d, r)
+
+		// Assert
+		require.Nil(t, err)
 
 		require.Equal(t, "rocks", r.url.Query().Get("go"))
 		require.Equal(t, "tests", r.url.Query().Get("fun"))


### PR DESCRIPTION
- `Responder` writes JSON and HTML data to a `*bytes.Buffer` (managed by a `*sync.Pool`) before copying to `ResponseWriter`.
  - The quantity of data attempted to be encoded by the appropriate functions in `json` and `html` can be too much. Standard advice is to write that to a buffer first, allowing that to error, and gracefully writing the appropriate status code
- Fixes bug in `*Responder.Json` that always wrote `currentUser` data due to this being a default field
- `Param(key, value string)` -> `Params(values map[string]string)`
- Adds benchmarks