### PR TITLE
Log message location matches call site through configuration

### DIFF
--- a/http/example/main.go
+++ b/http/example/main.go
@@ -102,7 +102,7 @@ func (h *Handler) broken(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	env := "EXAMPLE"
-	log := logger.NewLogger()
+	log := logger.New()
 	u, err := url.ParseRequestURI("localhost:8081")
 	if err != nil {
 		log.Fatal(err.Error(), nil)

--- a/http/resp/responder.go
+++ b/http/resp/responder.go
@@ -16,6 +16,8 @@ import (
 	"github.com/xy-planning-network/trails/logger"
 )
 
+const responderFrames = 0
+
 // Responder maintains reusable pieces for responding to HTTP requests.
 // It exposes many common methods for writing structured data as an HTTP response.
 // These are the forms of response Responder can execute:
@@ -83,6 +85,11 @@ func NewResponder(opts ...ResponderOptFn) *Responder {
 	if d.logger == nil {
 		d.logger = logger.NewLogger()
 	}
+
+	if l, ok := d.logger.(logger.SkipLogger); ok {
+		d.logger = l.AddSkip(responderFrames)
+	}
+
 	if d.parser != nil {
 		d.parser.AddFn(template.Nonce())
 		if d.rootUrl != nil {
@@ -109,7 +116,7 @@ func (doer Responder) CurrentUser(ctx context.Context) (any, error) {
 //
 // Use in exceptional circumstances when no Redirect or Html can occur.
 func (doer *Responder) Err(w http.ResponseWriter, r *http.Request, err error, opts ...Fn) {
-	rr, nested := doer.do(w, r, opts...)
+	rr, nested := doer.do(w, r, append(opts, Err(err))...)
 	defer r.Body.Close()
 	if nested != nil {
 		err = fmt.Errorf("%w: %s", err, nested)
@@ -120,12 +127,6 @@ func (doer *Responder) Err(w http.ResponseWriter, r *http.Request, err error, op
 		msg = err.Error()
 	}
 
-	if rr.user == nil {
-		populateUser(*doer, rr) // NOTE(dlk): ignore err since user is not required
-	}
-
-	u, _ := rr.user.(logger.LogUser)
-	doer.logger.Error(msg, newLogContext(r, err, rr.data, u))
 	if rr.code == 0 {
 		rr.code = http.StatusInternalServerError
 	}

--- a/http/resp/responder.go
+++ b/http/resp/responder.go
@@ -83,7 +83,7 @@ func NewResponder(opts ...ResponderOptFn) *Responder {
 	}
 
 	if d.logger == nil {
-		d.logger = logger.NewLogger()
+		d.logger = logger.New()
 	}
 
 	if l, ok := d.logger.(logger.SkipLogger); ok {

--- a/http/resp/responder_opt.go
+++ b/http/resp/responder_opt.go
@@ -79,7 +79,7 @@ func WithCtxKeys(keys ...ctx.CtxKeyable) func(*Responder) {
 // If no Logger is provided through this option, a defaultLogger will be configured.
 func WithLogger(log logger.Logger) func(*Responder) {
 	if log == nil {
-		log = logger.NewLogger()
+		log = logger.New()
 	}
 	return func(d *Responder) {
 		d.logger = log

--- a/http/resp/responder_opt_test.go
+++ b/http/resp/responder_opt_test.go
@@ -1,7 +1,9 @@
 package resp
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net/url"
 	"testing"
 
@@ -48,9 +50,22 @@ func TestResponderWithCtxKeys(t *testing.T) {
 }
 
 func TestResponderWithLogger(t *testing.T) {
-	l := logger.NewLogger()
-	d := NewResponder(WithLogger(l))
-	require.Equal(t, l, d.logger)
+	// Arrange
+	b := new(bytes.Buffer)
+	l := log.New(b, "", log.LstdFlags)
+	ll := logger.NewLogger(logger.WithLogger(l))
+	d := NewResponder(WithLogger(ll))
+
+	msg := "unit testing is fun!"
+
+	// Act
+	d.logger.Info(msg, nil)
+
+	// Assert
+	actual := b.String()
+	require.Contains(t, actual, "[INFO]")
+	require.Contains(t, actual, "responder_opt_test.go")
+	require.Contains(t, actual, msg)
 }
 
 func TestResponderWithParser(t *testing.T) {

--- a/http/resp/responder_opt_test.go
+++ b/http/resp/responder_opt_test.go
@@ -53,7 +53,7 @@ func TestResponderWithLogger(t *testing.T) {
 	// Arrange
 	b := new(bytes.Buffer)
 	l := log.New(b, "", log.LstdFlags)
-	ll := logger.NewLogger(logger.WithLogger(l))
+	ll := logger.New(logger.WithLogger(l))
 	d := NewResponder(WithLogger(ll))
 
 	msg := "unit testing is fun!"

--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -10,6 +10,8 @@ import (
 	"github.com/xy-planning-network/trails/logger"
 )
 
+const responseFnFrames = 3
+
 // A Fn is a functional option that mutates the state of the Response.
 type Fn func(Responder, *Response) error
 
@@ -82,7 +84,11 @@ func Err(e error) Fn {
 			populateUser(d, r) // NOTE(dlk): ignore err since a user is not required
 
 			u, _ := r.user.(logger.LogUser)
-			d.logger.Error(e.Error(), newLogContext(r.r, e, r.data, u))
+			l := d.logger
+			if sl, ok := d.logger.(logger.SkipLogger); ok {
+				l = sl.AddSkip(responderFrames + responseFnFrames)
+			}
+			l.Error(e.Error(), newLogContext(r.r, e, r.data, u))
 		}
 
 		if err := Code(http.StatusInternalServerError)(d, r); err != nil {
@@ -389,7 +395,11 @@ func Warn(msg string) Fn {
 		populateUser(d, r) // NOTE(dlk): ignore since a user is not required
 
 		u, _ := r.user.(logger.LogUser)
-		d.logger.Warn(msg, newLogContext(r.r, errors.New(msg), r.data, u))
+		l := d.logger
+		if sl, ok := d.logger.(logger.SkipLogger); ok {
+			l = sl.AddSkip(responderFrames + responseFnFrames)
+		}
+		l.Warn(msg, newLogContext(r.r, errors.New(msg), r.data, u))
 
 		if err := Flash(session.Flash{Type: session.FlashWarning, Msg: msg})(d, r); err != nil {
 			return err

--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -86,7 +86,7 @@ func Err(e error) Fn {
 			u, _ := r.user.(logger.LogUser)
 			l := d.logger
 			if sl, ok := d.logger.(logger.SkipLogger); ok {
-				l = sl.AddSkip(responderFrames + responseFnFrames)
+				l = sl.AddSkip(sl.Skip() + responseFnFrames)
 			}
 			l.Error(e.Error(), newLogContext(r.r, e, r.data, u))
 		}
@@ -397,7 +397,7 @@ func Warn(msg string) Fn {
 		u, _ := r.user.(logger.LogUser)
 		l := d.logger
 		if sl, ok := d.logger.(logger.SkipLogger); ok {
-			l = sl.AddSkip(responderFrames + responseFnFrames)
+			l = sl.AddSkip(sl.Skip() + responseFnFrames)
 		}
 		l.Warn(msg, newLogContext(r.r, errors.New(msg), r.data, u))
 

--- a/logger/context.go
+++ b/logger/context.go
@@ -63,7 +63,6 @@ func (lc LogContext) MarshalText() ([]byte, error) {
 		if len(r) > 0 {
 			m["request"] = r
 		}
-
 	}
 
 	if lc.User != nil {

--- a/logger/doc.go
+++ b/logger/doc.go
@@ -1,6 +1,45 @@
 /*
 
-Package logger defines how to log in trails as well as provide a default implementation of that interface.
+Package logger provides logging functionality to a trails app by defining the required behavior in Logger
+and providing an implementation of it with TrailsLogger.
+
+Overview
+
+The Logger interface outputs messages at certain levels of importance.
+LogLevel is the type to use to represent those levels.
+An implementation of Logger may be initialized at a certain LogLevel
+and only emit messages at or above that level of importance.
+For example, TrailsLogger accepts a LogLevel,
+and if initialized with LogLevelWarn,
+only (*TrailsLogger).Warn, (*TrailsLogger).Error, and (*TrailsLogger).Fatal produce messages.
+
+TrailsLogger
+
+The TrailsLogger provides all the logging functionality needed for a trails app.
+It is the implementation of Logger returned by the New function.
+
+Log messages emitted by TrailsLogger are composed of a few parts:
+- timestamp
+- log level
+- call site
+- message
+- log context
+
+Here's an example:
+	2022/04/28 15:55:21 [DEBUG] web/dashboard_handler.go:43 'such fun!' log_context: "{"user":"{"id": 1, "email": "trails@example.com"}}"
+
+The file, line number, and parent directory of where a TrailsLogger comprise the call site.
+The message is the actual string passed into the TrailsLogger method, in this example, (*TrailsLogger).Debug.
+Lastly, the log context is a JSON-encoded *LogContext.
+The last component allows for including additional data inessential to the message proper,
+but provides a fuller picture of the application state at the time of logging.
+
+SkipLogger
+
+Sometimes, especially with internal packages, the file and line number in a log needs to be configurable.
+SkipLogger provides additional configuration functionality by setting the number of frames to skip
+back in order to reach the desired caller.
+For an example use case, review trails/http/resp.
 
 */
 package logger

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -80,12 +80,12 @@ type TrailsLogger struct {
 	ll   LogLevel
 }
 
-// NewLogger constructs a TrailsLogger.
+// New constructs a TrailsLogger.
 //
 // Logs are printed to os.Stdout by default, using the std lib log pkg.
 // The default environment is DEVELOPMENT.
 // The default log level is DEBUG.
-func NewLogger(opts ...LoggerOptFn) Logger {
+func New(opts ...LoggerOptFn) Logger {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	l := &TrailsLogger{
 		env: getEnvOrString("ENVIRONEMNT", "DEVELOPMENT"),

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,8 +25,11 @@ type Logger interface {
 	LogLevel() LogLevel
 }
 
+// The SkipLogger interface defines a Logger that scrolls back
+// the number of frames provided in order to ascertain the call site.
 type SkipLogger interface {
 	AddSkip(i int) SkipLogger
+	Skip() int
 	Logger
 }
 
@@ -101,6 +104,11 @@ func NewLogger(opts ...LoggerOptFn) Logger {
 	return l
 }
 
+// AddSkip replaces the current number of frames to scroll back
+// when logging a message.
+//
+// Use Skip to get the current skip amount
+// when needing to add to it with AddSkip.
 func (l *TrailsLogger) AddSkip(i int) SkipLogger {
 	newl := *l
 	newl.skip = i
@@ -154,6 +162,10 @@ func (l *TrailsLogger) Warn(msg string, ctx *LogContext) {
 
 // LogLevel returns the LogLevel set for the TrailsLogger.
 func (l *TrailsLogger) LogLevel() LogLevel { return l.ll }
+
+// Skip returns the current amount of frames to scroll back
+// when logging a message.
+func (l *TrailsLogger) Skip() int { return l.skip }
 
 // log executes printing the log message,
 // including any context if available.

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -22,7 +22,7 @@ func TestTrailsLoggerDebug(t *testing.T) {
 	expected := []byte("hello")
 	b := new(bytes.Buffer)
 	l := newTestLogger(b)
-	tl := logger.NewLogger(logger.WithLogger(l))
+	tl := logger.New(logger.WithLogger(l))
 
 	// Act
 	tl.Debug(string(expected), nil)
@@ -31,7 +31,7 @@ func TestTrailsLoggerDebug(t *testing.T) {
 	require.Nil(t, b.Bytes())
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLevel(logger.LogLevelDebug), logger.WithLogger(l))
+	tl = logger.New(logger.WithLevel(logger.LogLevelDebug), logger.WithLogger(l))
 
 	// Act
 	tl.Debug(string(expected), nil)
@@ -48,7 +48,7 @@ func TestTrailsLoggerError(t *testing.T) {
 	expected := []byte("hello")
 	b := new(bytes.Buffer)
 	l := newTestLogger(b)
-	tl := logger.NewLogger(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
+	tl := logger.New(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
 
 	// Act
 	tl.Error(string(expected), nil)
@@ -57,7 +57,7 @@ func TestTrailsLoggerError(t *testing.T) {
 	require.Nil(t, b.Bytes())
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLevel(logger.LogLevelError), logger.WithLogger(l))
+	tl = logger.New(logger.WithLevel(logger.LogLevelError), logger.WithLogger(l))
 
 	// Act
 	tl.Error(string(expected), nil)
@@ -69,7 +69,7 @@ func TestTrailsLoggerError(t *testing.T) {
 	require.Equal(t, expected, msgRegexp.FindAllSubmatch(actual, 1)[0][1])
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLogger(l))
+	tl = logger.New(logger.WithLogger(l))
 
 	// Act
 	tl.Error(string(expected), nil)
@@ -86,7 +86,7 @@ func TestTrailsLoggerFatal(t *testing.T) {
 	expected := []byte("hello")
 	b := new(bytes.Buffer)
 	l := newTestLogger(b)
-	tl := logger.NewLogger(logger.WithLogger(l))
+	tl := logger.New(logger.WithLogger(l))
 
 	// Act
 	tl.Fatal(string(expected), nil)
@@ -98,7 +98,7 @@ func TestTrailsLoggerFatal(t *testing.T) {
 	require.Equal(t, expected, msgRegexp.FindAllSubmatch(actual, 1)[0][1])
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
+	tl = logger.New(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
 
 	// Act
 	tl.Fatal(string(expected), nil)
@@ -115,7 +115,7 @@ func TestTrailsLoggerInfo(t *testing.T) {
 	expected := []byte("hello")
 	b := new(bytes.Buffer)
 	l := newTestLogger(b)
-	tl := logger.NewLogger(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
+	tl := logger.New(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
 
 	// Act
 	tl.Info(string(expected), nil)
@@ -124,7 +124,7 @@ func TestTrailsLoggerInfo(t *testing.T) {
 	require.Nil(t, b.Bytes())
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLevel(logger.LogLevelInfo), logger.WithLogger(l))
+	tl = logger.New(logger.WithLevel(logger.LogLevelInfo), logger.WithLogger(l))
 
 	// Act
 	tl.Info(string(expected), nil)
@@ -136,7 +136,7 @@ func TestTrailsLoggerInfo(t *testing.T) {
 	require.Equal(t, expected, msgRegexp.FindAllSubmatch(actual, 1)[0][1])
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLogger(l))
+	tl = logger.New(logger.WithLogger(l))
 
 	// Act
 	tl.Info(string(expected), nil)
@@ -152,7 +152,7 @@ func TestTrailsLoggerWarn(t *testing.T) {
 	expected := []byte("hello")
 	b := new(bytes.Buffer)
 	l := newTestLogger(b)
-	tl := logger.NewLogger(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
+	tl := logger.New(logger.WithLevel(logger.LogLevelFatal), logger.WithLogger(l))
 
 	// Act
 	tl.Warn(string(expected), nil)
@@ -161,7 +161,7 @@ func TestTrailsLoggerWarn(t *testing.T) {
 	require.Nil(t, b.Bytes())
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLevel(logger.LogLevelWarn), logger.WithLogger(l))
+	tl = logger.New(logger.WithLevel(logger.LogLevelWarn), logger.WithLogger(l))
 
 	// Act
 	tl.Warn(string(expected), nil)
@@ -173,7 +173,7 @@ func TestTrailsLoggerWarn(t *testing.T) {
 	require.Equal(t, expected, msgRegexp.FindAllSubmatch(actual, 1)[0][1])
 
 	// Arrange
-	tl = logger.NewLogger(logger.WithLogger(l))
+	tl = logger.New(logger.WithLogger(l))
 
 	// Act
 	tl.Warn(string(expected), nil)

--- a/logger/opt.go
+++ b/logger/opt.go
@@ -25,3 +25,12 @@ func WithLogger(log *log.Logger) func(*TrailsLogger) {
 		l.l = log
 	}
 }
+
+// WithSkip sets the number of frames in the call stack
+// to skip in order to log the desired file and line number
+// of the calling code.
+func WithSkip(skip int) func(*TrailsLogger) {
+	return func(l *TrailsLogger) {
+		l.skip = skip
+	}
+}

--- a/logger/sentry.go
+++ b/logger/sentry.go
@@ -25,13 +25,16 @@ func NewSentryLogger(tl *TrailsLogger, dsn string) Logger {
 		return tl
 	}
 
-	l := tl.AddSkip(1)
+	l := tl.AddSkip(1 + tl.Skip())
 	return &SentryLogger{l: l}
 }
 
-func (sl *SentryLogger) AddSkip(i int) SkipLogger {
-	return sl.l.AddSkip(i + sl.skip)
-}
+// AddSkip replaces the current number of frames to scroll back
+// when logging a message.
+//
+// Use Skip to get the current skip amount
+// when needing to add to it with AddSkip.
+func (sl *SentryLogger) AddSkip(i int) SkipLogger { return sl.l.AddSkip(i) }
 
 // Debug writes a debug log.
 func (sl *SentryLogger) Debug(msg string, ctx *LogContext) {
@@ -75,6 +78,10 @@ func (sl *SentryLogger) Warn(msg string, ctx *LogContext) {
 
 // LogLevel returns the LogLevel set for the SentryLogger.
 func (sl *SentryLogger) LogLevel() LogLevel { return sl.l.LogLevel() }
+
+// Skip returns the current amount of frames to scroll back
+// when logging a message.
+func (sl *SentryLogger) Skip() int { return sl.l.Skip() }
 
 // send ships the LogContext.Error to Sentry,
 // including any additional data from LogContext.

--- a/logger/sentry.go
+++ b/logger/sentry.go
@@ -6,13 +6,15 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-// A SentryLogger
+// A SentryLogger logs messages and reports sufficiently important
+// ones to error tracking software Sentry (sentry.io).
 type SentryLogger struct {
 	l    SkipLogger
 	skip int
 }
 
-// NewSentryLogger constructs a SentryLogger based off the provided TrailsLogger.
+// NewSentryLogger constructs a SentryLogger based off the provided TrailsLogger,
+// routing messages to the DSN provided.
 func NewSentryLogger(tl *TrailsLogger, dsn string) Logger {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:          dsn,


### PR DESCRIPTION
### Problem
Previously, `logger.TrailsLogger` inflexibly assumed the caller to a method (`Logger.Debug`, `Logger.Info`, etc.) was a fixed number of steps up in the stack. When an app logged a message, this was fine. Messages looked like:
```
2022/04/29 10:53:58 /tmp/build_1739b51c/procedures/subscription.go:295 'record not found'
```

The problem with this approach was most notably seen when using `resp.Responder` and any of the functional options that log a message (`resp.Err`, `resp.Warn`). The file and line number of the `trails` package was always logged, which was uninformative and not the intention of the end user
```
2022/04/29 10:53:58 [DEBUG] trails@v0.3.14/http/resp/responder.go:41 'such fun!'
```

### Solution
Now, `logger` introduces another interface `SkipLogger` which allows for setting how many frames in the call stack to scroll back. A `SkipLogger` can be configured for a certain area of an application or can be ad hoc initialized at the same point of logging. Both of these strategies are utilized in `trails`. With the former, a `SentryLogger` adds its own number of frames to the existing number to skip. With the latter, `resp.Err` and `resp.Warn` instantiate a new `SkipLogger` with `AddSkip` each time they are called themselves. In both cases, when a `TrailsLogger` backs it, messages look like:
```
2022/04/28 15:55:21 [INFO] trails/http/middleware/log_request.go:41 '0.0.0.0 GET /dashboard'
2022/04/28 15:55:21 [DEBUG] web/dashboard_handler.go:43 'such fun!'
```

Notably, the first log message still logs `trails` package, which is what is intended here. We in fact want the log call site to the specific middleware making the log call. For the second message, the situation is different, and we do not want the `trails` package that actually executed the log call and instead want where that `trails` package was called.

A second, small change seen above is the filepath. For non-`trails` calls, `logger` prints the file and it's most immediate parent directory instead of the fully qualified filepath. Because of our generally flat project structure, these two pieces of information (in my view) are the most salient whereas anything else is noise. This could be a configurable option in the future.

### Tradeoffs
The biggest tradeoff is not capturing a feeling of "it just works" for the `TrailsLogger`, at least within `trails` packages. When working on a `trails` package that leverages a `TrailsLogger` have to keep in mind and test the fact they are a certain number of frames in the call stack. Same goes for whenever an end user is, say, developing an internal package. I do not anticipate `SkipLogger.AddSkip` being a heavily utilized feature and so may be lost in the mix.