### PR TITLE
ApplyAuthorizer -> AuthorizeApplicator

### DIFF
--- a/http/middleware/authorize.go
+++ b/http/middleware/authorize.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/xy-planning-network/trails/http/keyring"
+	"github.com/xy-planning-network/trails/http/resp"
+	"github.com/xy-planning-network/trails/http/session"
+)
+
+// An AuthorizeApplicator constructs Adapters that apply custom authorization rules
+// for users, as specified by type T.
+type AuthorizeApplicator[T any] struct {
+	d *resp.Responder
+	k keyring.Keyable
+}
+
+// NewAuthorizeApplicator constructs an AuthorizeApplicator for type T.
+// Apply methods for the constructed AuthorizeApplicator will use the Responder for redirects.
+// Apply methods will use the keyring.Keyable to pull a user out of the request Context.
+// Accordingly, the keyring.Keyable provided ought to be the same
+// as that returned by keyring.CurrentUserKey().
+func NewAuthorizeApplicator[T any](d *resp.Responder, k keyring.Keyable) AuthorizeApplicator[T] {
+	return AuthorizeApplicator[T]{d, k}
+}
+
+// Apply wraps a custom function validating the authorization of a user,
+// whose type is specified by T.
+//
+// Using the kerying.Keyable the AuthorizeApplicator was constructed with,
+// Apply retrieves the value for that key from the request Context.
+// If it cannot be cast to type T, Apply panics.
+//
+// The provided custom function returns either true and an empty string -
+// meaning the user is authorized - or false and a valid URL as a string.
+//
+// If the custom function returns true,
+// Apply passes the request to the next handler in the middleware stack.
+//
+// If the custom function returns false,
+// Apply does not pass the request to the next handler in the middleware stack.
+//
+// Instead, Apply takes one of two actions
+// depending on the "Accept" HTTP header of the request.
+// - By default, Apply writes 401.
+// - If "text/html" appears in the "Accept" header, though,
+//   Apply sets a "no access" flash on the session
+//   and redirects to the URL the custom function returns.
+//
+// If fn is nil, Apply returns a NoopAdapter.
+func (aa AuthorizeApplicator[T]) Apply(fn func(user T) (string, bool)) Adapter {
+	if fn == nil {
+		return NoopAdapter
+	}
+
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if url, ok := fn(r.Context().Value(aa.k).(T)); !ok {
+				vs := r.Header.Values("Accept")
+				for _, v := range vs {
+					if strings.Compare(v, "text/html") == 0 {
+						f := session.Flash{Type: session.FlashWarning, Msg: session.NoAccessMsg}
+						aa.d.Redirect(w, r, resp.Flash(f), resp.Url(url))
+
+						return
+					}
+				}
+
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			handler.ServeHTTP(w, r)
+		})
+	}
+}

--- a/http/middleware/authorize.go
+++ b/http/middleware/authorize.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -30,7 +31,8 @@ func NewAuthorizeApplicator[T any](d *resp.Responder, k keyring.Keyable) Authori
 //
 // Using the kerying.Keyable the AuthorizeApplicator was constructed with,
 // Apply retrieves the value for that key from the request Context.
-// If it cannot be cast to type T, Apply panics.
+// Apply should not be used in a situation where the http.Request.Context
+// in some cases stores the requisite value and others does not.
 //
 // The provided custom function returns either true and an empty string -
 // meaning the user is authorized - or false and a valid URL as a string.
@@ -56,15 +58,24 @@ func (aa AuthorizeApplicator[T]) Apply(fn func(user T) (string, bool)) Adapter {
 
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if url, ok := fn(r.Context().Value(aa.k).(T)); !ok {
-				vs := r.Header.Values("Accept")
-				for _, v := range vs {
-					if strings.Compare(v, "text/html") == 0 {
-						f := session.Flash{Type: session.FlashWarning, Msg: session.NoAccessMsg}
-						aa.d.Redirect(w, r, resp.Flash(f), resp.Url(url))
+			doRedirect := acceptsTextHtml(r.Header)
 
-						return
+			val, ok := r.Context().Value(aa.k).(T)
+			if !ok {
+				err := fmt.Errorf("value in request context for key %q is not %T", aa.k.String(), val)
+				aa.d.Err(w, r, err)
+				return
+			}
+
+			if url, ok := fn(val); !ok {
+				if doRedirect {
+					// TODO(dlk): configurable to not add a flash?
+					f := session.Flash{Type: session.FlashWarning, Msg: session.NoAccessMsg}
+					if err := aa.d.Redirect(w, r, resp.Flash(f), resp.Url(url)); err != nil {
+						aa.d.Err(w, r, err)
 					}
+
+					return
 				}
 
 				w.WriteHeader(http.StatusUnauthorized)
@@ -74,4 +85,16 @@ func (aa AuthorizeApplicator[T]) Apply(fn func(user T) (string, bool)) Adapter {
 			handler.ServeHTTP(w, r)
 		})
 	}
+}
+
+// acceptsTextHtml asserts whether the requests accepts rendered HTML or not.
+func acceptsTextHtml(header http.Header) bool {
+	vs := header.Values("Accept")
+	for _, v := range vs {
+		if strings.Compare(v, "text/html") == 0 {
+			return true
+		}
+	}
+
+	return false
 }

--- a/http/middleware/authorize_test.go
+++ b/http/middleware/authorize_test.go
@@ -1,7 +1,107 @@
 package middleware_test
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails/http/middleware"
+	"github.com/xy-planning-network/trails/http/resp"
+	"github.com/xy-planning-network/trails/http/session"
+)
 
 func TestAuthorizeApplicator(t *testing.T) {
-	// TODO
+	// Arrange
+	app := middleware.NewAuthorizeApplicator[testUser](nil, nil)
+
+	// Act
+	adpt := app.Apply(nil)
+
+	// Assert
+	require.Equal(t, fmt.Sprintf("%p", middleware.NoopAdapter), fmt.Sprintf("%p", adpt))
+
+	// Arrange
+	sk := ctxKey("session")
+	uk := ctxKey("user")
+	d := resp.NewResponder(resp.WithSessionKey(sk), resp.WithUserSessionKey(uk))
+
+	app = middleware.NewAuthorizeApplicator[testUser](d, uk)
+	adpt = app.Apply(func(u testUser) (string, bool) {
+		if u {
+			return "", true
+		}
+
+		return "/oops", false
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+
+	// Act
+	adpt(teapotHandler()).ServeHTTP(w, r)
+
+	//	Assert
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Arrange
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(false)))
+
+	// Act
+	adpt(teapotHandler()).ServeHTTP(w, r)
+
+	//	Assert
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Arrange
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(false)))
+
+	for _, v := range []string{"text/html",
+		"application/xhtml+xml",
+		"application/xml;q=0.9",
+		"image/avif",
+		"image/webp",
+		"*/*",
+	} {
+		r.Header.Add("Accept", v)
+	}
+
+	// Act
+	adpt(teapotHandler()).ServeHTTP(w, r)
+
+	//	Assert
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Arrange
+	var ss session.Stub
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	r = r.WithContext(context.WithValue(r.Context(), sk, ss))
+	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(false)))
+	r.Header.Set("Accept", "text/html")
+
+	// Act
+	adpt(teapotHandler()).ServeHTTP(w, r)
+
+	//	Assert
+	require.Equal(t, http.StatusFound, w.Code)
+	require.Equal(t, "/oops", w.Header().Get("Location"))
+
+	// Arrange
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(true)))
+
+	// Act
+	adpt(teapotHandler()).ServeHTTP(w, r)
+
+	//	Assert
+	require.Equal(t, http.StatusTeapot, w.Code)
 }

--- a/http/middleware/authorize_test.go
+++ b/http/middleware/authorize_test.go
@@ -1,0 +1,7 @@
+package middleware_test
+
+import "testing"
+
+func TestAuthorizeApplicator(t *testing.T) {
+	// TODO
+}


### PR DESCRIPTION
`AuthorizeApplicator` is a generic struct enabling developers to create functions that check whether their application users are authorized to access a resource. This rewrites `ApplyAuthorizer`, which put the onus on developers to accept `any` from `trails` and cast to their local type before checking authorization. Here's functions used by `ApplyAuthorizer` could be rewritten for `AuthorizeApplicator[T].Apply`

**ApplyAuthorizer**
```golang
func hasAccess(u interface{}) (string, bool) {
	cu, ok := u.(*User)
	if !ok {
		return "/", false
	}

	if cu.AccessState != trails.AccessGranted {
		return cu.HomePath(), false
	}

	return "", true
}
```

Such a function would be used as such:
```golang
router.Route{
  Path: "/",
  Method: http.MethodGet,
  Handler: myHandler,
  Middlewares: []middleware.Adapter{middleware.ApplyAuthorizer(myResponder, myUserKey, hasAccess)},
}
```

**AuthorizeApplicator[\*User].Apply**
```golang
func hasAccess(u *User) (string, bool) {
	if cu.AccessState != trails.AccessGranted {
		return cu.HomePath(), false
	}

	return "", true
}
```

Such a function would be used as such:
```golang
// Reuse this AuthorizeApplicator where other middleware.Adapters are need
aa := middleware.AuthorizeApplicator[*User](myResponder, myUserKey)
router.Route{
  Path: "/",
  Method: http.MethodGet,
  Handler: myHandler,
  Middlewares: []middleware.Adapter{aa.Apply(hasAccess)},
}
```