### PR TITLE
Resolves redirect bug

### DIFF
--- a/http/middleware/authorize.go
+++ b/http/middleware/authorize.go
@@ -89,11 +89,9 @@ func (aa AuthorizeApplicator[T]) Apply(fn func(user T) (string, bool)) Adapter {
 
 // acceptsTextHtml asserts whether the requests accepts rendered HTML or not.
 func acceptsTextHtml(header http.Header) bool {
-	vs := header.Values("Accept")
-	for _, v := range vs {
-		if strings.Compare(v, "text/html") == 0 {
-			return true
-		}
+	v := header.Get("Accept")
+	if strings.Index(v, "text/html") == 0 {
+		return true
 	}
 
 	return false

--- a/http/middleware/authorize_test.go
+++ b/http/middleware/authorize_test.go
@@ -62,7 +62,8 @@ func TestAuthorizeApplicator(t *testing.T) {
 	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
 	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(false)))
 
-	for _, v := range []string{"text/html",
+	for _, v := range []string{
+		"text/html",
 		"application/xhtml+xml",
 		"application/xml;q=0.9",
 		"image/avif",

--- a/http/middleware/authorize_test.go
+++ b/http/middleware/authorize_test.go
@@ -82,11 +82,14 @@ func TestAuthorizeApplicator(t *testing.T) {
 	// Arrange
 	var ss session.Stub
 
+	v := "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*"
+
 	w = httptest.NewRecorder()
 	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
 	r = r.WithContext(context.WithValue(r.Context(), sk, ss))
 	r = r.WithContext(context.WithValue(r.Context(), uk, testUser(false)))
-	r.Header.Set("Accept", "text/html")
+
+	r.Header.Set("Accept", v)
 
 	// Act
 	adpt(teapotHandler()).ServeHTTP(w, r)


### PR DESCRIPTION
## Problem statement
Endpoints that use the `AuthorizeApplicator` were not redirecting properly due to a `401` status code returning and not a proper redirect.

## What this does
The existing solution was too brittle/narrow. Take a look at the unit tests which support both the header supplying many values and it not. The latter - that the "Accept" header is seen as a single string - is now the expected, "happy path" case.

I am unsure why this stopped working and don't have an interest in scratching the surface too deep. At first I thought it was a Firefox thing, but it isn't. Both Firefox & Chrome's "Accept" headers are parsed as a single long string by `net/http` instead of multiple values.