### PR TITLE
ranger & session.UserStorer refactor

### DIFF
--- a/http/middleware/current_user_test.go
+++ b/http/middleware/current_user_test.go
@@ -29,7 +29,7 @@ func TestCurrentUser(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%p", middleware.NoopAdapter), fmt.Sprintf("%p", actual))
 
 	// Arrange + Act
-	actual = middleware.CurrentUser(resp.NewResponder(), testUserStore(testUser(true)), nil, nil)
+	actual = middleware.CurrentUser(resp.NewResponder(), newTestUserStore(true), nil, nil)
 
 	// Assert
 	require.Equal(t, fmt.Sprintf("%p", middleware.NoopAdapter), fmt.Sprintf("%p", actual))
@@ -44,7 +44,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com/test")),
-		testUserStore(testUser(true)),
+		newTestUserStore(true),
 		sessKey,
 		userKey,
 	)(teapotHandler()).ServeHTTP(w, r)
@@ -61,7 +61,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com")),
-		testUserStore(testUser(true)),
+		newTestUserStore(true),
 		sessKey,
 		userKey,
 	)(teapotHandler()).ServeHTTP(w, r)
@@ -78,7 +78,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	actual = middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com")),
-		testUserStore(testUser(true)),
+		newTestUserStore(true),
 		sessKey,
 		userKey,
 	)
@@ -99,7 +99,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com")),
-		failedUserStore(testUser(true)),
+		newFailedUserStore(true),
 		sessKey,
 		userKey,
 	)(teapotHandler()).ServeHTTP(w, r)
@@ -116,7 +116,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com")),
-		testUserStore(testUser(false)),
+		newTestUserStore(false),
 		sessKey,
 		userKey,
 	)(teapotHandler()).ServeHTTP(w, r)
@@ -133,7 +133,7 @@ func TestCurrentUser(t *testing.T) {
 	// Act
 	actual = middleware.CurrentUser(
 		resp.NewResponder(resp.WithRootUrl("https://example.com")),
-		testUserStore(testUser(true)),
+		newTestUserStore(true),
 		sessKey,
 		userKey,
 	)

--- a/http/middleware/middleware_test.go
+++ b/http/middleware/middleware_test.go
@@ -29,13 +29,17 @@ func (testUser) HomePath() string  { return "/" }
 func (testUser) GetEmail() string  { return "user@example.com" }
 func (testUser) GetID() uint       { return 1 }
 
-type testUserStore testUser
+func newTestUserStore(b bool) middleware.UserStorer {
+	return func(_ uint) (middleware.User, error) {
+		return testUser(b), nil
+	}
+}
 
-func (s testUserStore) GetByID(_ uint) (middleware.User, error) { return testUser(s), nil }
-
-type failedUserStore testUser
-
-func (s failedUserStore) GetByID(_ uint) (middleware.User, error) { return testUser(s), errors.New("") }
+func newFailedUserStore(b bool) middleware.UserStorer {
+	return func(_ uint) (middleware.User, error) {
+		return testUser(b), errors.New("")
+	}
+}
 
 func teapotHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/postgres/service.go
+++ b/postgres/service.go
@@ -30,38 +30,38 @@ type PagedData struct {
 
 // DatabaseServiceImpl satisfies the above DatabaseService interface.
 type DatabaseServiceImpl struct {
-	db *gorm.DB
+	DB *gorm.DB
 }
 
 // NewService hydrates the gorm database for the implementation struct methods.
 func NewService(DB *gorm.DB) *DatabaseServiceImpl {
-	return &DatabaseServiceImpl{db: DB}
+	return &DatabaseServiceImpl{DB: DB}
 }
 
 // CountByQuery recives a database model and query and fetches a count for the given params.
 func (service *DatabaseServiceImpl) CountByQuery(model any, query map[string]any) (int64, error) {
 	count := int64(0)
-	return count, service.db.Model(model).Where(query).Count(&count).Error
+	return count, service.DB.Model(model).Where(query).Count(&count).Error
 }
 
 // FetchByQuery receives a slice of database models as a pointer and fetches all records matching the query.
 func (service *DatabaseServiceImpl) FetchByQuery(models any, query string, params []any) error {
-	return service.db.Where(query, params...).Find(models).Error
+	return service.DB.Where(query, params...).Find(models).Error
 }
 
 // FindByID receives a database model as a pointer and fetches it using the primary ID.
 func (service *DatabaseServiceImpl) FindByID(model any, ID any) error {
-	return service.db.First(model, ID).Error
+	return service.DB.First(model, ID).Error
 }
 
 // FindByQuery receives a database model as a pointer and fetches it using the given query.
 func (service *DatabaseServiceImpl) FindByQuery(model any, query map[string]any) error {
-	return service.db.Where(query).First(model).Error
+	return service.DB.Where(query).First(model).Error
 }
 
 // Insert receives a database model and inserts it into the database.
 func (service *DatabaseServiceImpl) Insert(model any) error {
-	return service.db.Create(model).Error
+	return service.DB.Create(model).Error
 }
 
 // PagedByQuery receives a slice of database models and paging information to build a paged database query.
@@ -78,13 +78,13 @@ func (service *DatabaseServiceImpl) PagedByQuery(models any, query string, param
 
 	// Conduct unlimited count query to calculate totals
 	var totalRecords int64
-	if err := service.db.Where(query, params...).Model(models).Count(&totalRecords).Error; err != nil {
+	if err := service.DB.Where(query, params...).Model(models).Count(&totalRecords).Error; err != nil {
 		return pd, err
 	}
 
 	// Calculate offset and conduct limited query
 	offset := (page - 1) * perPage
-	session := service.db
+	session := service.DB
 	for _, preload := range preloads {
 		session = session.Preload(preload)
 	}

--- a/ranger/config.go
+++ b/ranger/config.go
@@ -1,0 +1,50 @@
+package ranger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/xy-planning-network/trails"
+	"github.com/xy-planning-network/trails/http/middleware"
+	"github.com/xy-planning-network/trails/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type Config[User RangerUser] struct {
+	// NOTE(dlk): Ranger can accept a type parameter also.
+	// Config was chosen to minimize proliferating generic type parameters
+	// in all Ranger methods or references to Ranger.
+	// Config ought to be restricted to New.
+}
+
+// defaultUserStore constructs a function matching the signature of middleware.UserStorer.
+// This function pulls the User from the db by ID,
+// preloading all top-level associations.
+func (Config[User]) defaultUserStore(db postgres.DatabaseService) middleware.UserStorer {
+	findByID := db.FindByID
+
+	// NOTE(dlk): if ranger.Ranger.db was a *postgres.DatabaseServiceImpl
+	// instead of *postgres.DatabaseService,
+	// the type assertion would not be necessary;
+	// we are not ready to commit to this inflexibilty, yet.
+	if db, ok := db.(*postgres.DatabaseServiceImpl); ok {
+		findByID = func(model, id any) error {
+			return db.DB.Preload(clause.Associations).First(model, id).Error
+		}
+	}
+
+	return func(id uint) (middleware.User, error) {
+		var user User
+		err := findByID(&user, id)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = fmt.Errorf("%w: User %d", trails.ErrNotExist, id)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		return user, nil
+	}
+}

--- a/ranger/config.go
+++ b/ranger/config.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-type Config[User RangerUser] struct {
+type Config[U RangerUser] struct {
 	// NOTE(dlk): Ranger can accept a type parameter also.
 	// Config was chosen to minimize proliferating generic type parameters
 	// in all Ranger methods or references to Ranger.
@@ -21,7 +21,7 @@ type Config[User RangerUser] struct {
 // defaultUserStore constructs a function matching the signature of middleware.UserStorer.
 // This function pulls the User from the db by ID,
 // preloading all top-level associations.
-func (Config[User]) defaultUserStore(db postgres.DatabaseService) middleware.UserStorer {
+func (Config[U]) defaultUserStore(db postgres.DatabaseService) middleware.UserStorer {
 	findByID := db.FindByID
 
 	// NOTE(dlk): if ranger.Ranger.db was a *postgres.DatabaseServiceImpl
@@ -35,7 +35,7 @@ func (Config[User]) defaultUserStore(db postgres.DatabaseService) middleware.Use
 	}
 
 	return func(id uint) (middleware.User, error) {
-		var user User
+		var user U
 		err := findByID(&user, id)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			err = fmt.Errorf("%w: User %d", trails.ErrNotExist, id)

--- a/ranger/opt.go
+++ b/ranger/opt.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/xy-planning-network/trails/http/keyring"
-	"github.com/xy-planning-network/trails/http/middleware"
 	"github.com/xy-planning-network/trails/http/resp"
 	"github.com/xy-planning-network/trails/http/router"
 	"github.com/xy-planning-network/trails/http/session"
@@ -124,21 +123,6 @@ func WithSessionStore(store session.SessionStorer) RangerOption {
 	return func(rng *Ranger) (OptFollowup, error) {
 		rng.sessions = store
 		setupLog.Debug(fmt.Sprintf("using session store %T", store), nil)
-
-		return nil, nil
-	}
-}
-
-// WithUserSessions exposes the middleware.UserStorer
-// that will be used to injectg the current session and user into http.Request.Contexts.
-//
-// When WithUserSessions is called, it overrides the default middleware.UserStorer.
-// The default middleware.UserStorer gets or creates a postgres.DatabaseService connection.
-func WithUserSessions(users middleware.UserStorer) RangerOption {
-	return func(rng *Ranger) (OptFollowup, error) {
-		rng.users = users
-
-		setupLog.Debug(fmt.Sprintf("using user store %T", users), nil)
 
 		return nil, nil
 	}

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -53,7 +53,7 @@ type Ranger struct {
 // New constructs a Ranger from the provided options.
 // Default options are applied first followed by the options passed into New.
 // Options supplied to New overwrite default configurations.
-func New[User RangerUser](c Config[User], opts ...RangerOption) (*Ranger, error) {
+func New[User RangerUser](cfg Config[U], opts ...RangerOption) (*Ranger, error) {
 	r := new(Ranger)
 	followups := make([]OptFollowup, 0)
 
@@ -77,7 +77,7 @@ func New[User RangerUser](c Config[User], opts ...RangerOption) (*Ranger, error)
 		}
 	}
 
-	r.userstore = c.defaultUserStore(r.db)
+	r.userstore = cfg.defaultUserStore(r.db)
 
 	for _, fn := range followups {
 		if err := fn(); err != nil {


### PR DESCRIPTION
## Problem statement
The setup to get to a `session.UserStorer` that works with an application is not meeting our goals. First, it requires a tango with the application's procedures being configured first before a `*ranger.Ranger` can be constructed. Second, there's more than 1 way to set it up.

To be able to store the `currentUser` in a `*http.Request.Context`, an application must define how to retrieve the `currentUser` from a datastore before `middleware.CurrentUser` can then stash it in the context. For example, from `college-try`:
```go
func main() {
        ...
        procs := procedures.New()
        rng, err := ranger.New(
            ...
            ranger.WithUserSessions(userstorer{procs.User.GetByID}),
        )
        ...
}

type userstorer struct {
	get func(id uint) (domain.User, error)
}
func (u userstorer) GetByID(id uint) (middleware.User, error) {
	user, err := u.get(id)
	if err != nil {
		return nil, err
	}

	return middleware.User(&user), nil
}
```
This is cleaned up in `second-child` with:
```go
func main() {
        ...
        procs := procedures.New()
        rng, err := ranger.New(
            ...
            ranger.WithUserSessions(procs.User),
        )
        ...
}
```
This only proves the point: two ways to do one thing _and_ requires procedures to be setup before `ranger`.

## What this does
This PR introduces a config struct that is instantiated with an application's implementation of `middleware.User`: `Config[User middleware.User]`. Having this config struct accept a type parameter enables exposing that type to `ranger` and, by extension, the implementation of `middleware.UserStorer` it sets up.

How `ranger` retrieves the `currentUser` from the datastore is now generic and gives 1 way to do it. It uses a custom implementation of `postgres.DatabaseService` that wraps `postgres.DatabaseServiceImpl` - save `FindByID` - and knows what concrete type to use to perform that retrieval via the generic `Config`.

`postgres/service.DatabaseServiceImpl` exports the underlying `*gorm.DB` so that `ranger` can use it for preloading all of the associations the application's user has. This avoids some sort of additional configuration to `Config` or whatnot. This may prove too brittle or too narrow. For `college-try` and `second-child`, this is sufficient. For `wall-to-wall`, [it is not](https://github.com/xy-planning-network/wall-to-wall/blob/f8b2c7cb7599846ea9a32f13a865ecf2fc0bd4aa/procedures/user.go#L54-L74). I will have to review the application to see if this is in fact necessary, but it very well may not be.

## Discussion
Check out its use in `college-try`: https://github.com/xy-planning-network/college-try/pull/524
- [x] Should `middleware.User` be the interface to satisfy for `currentUser`? Should this be a `ranger` defined interface, which embeds `middleware.User`, instead?
  - Added `RangerUser`
- Can we accept the single layer of preloading occurring or do we need this to be configurable?
- [x] What do we think of the alternate definition for `Config`?
  - Rejected!