### PR TITLE
adds Toolbox, Tool, ToolAction definitions

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,7 +3,8 @@ package trails
 import "errors"
 
 var (
-	ErrBadConfig = errors.New("bad config")
-	ErrNotExist  = errors.New("not exist")
-	ErrNotValid  = errors.New("invalid")
+	ErrBadConfig   = errors.New("bad config")
+	ErrMissingData = errors.New("missing data")
+	ErrNotExist    = errors.New("not exist")
+	ErrNotValid    = errors.New("invalid")
 )

--- a/toolbox.go
+++ b/toolbox.go
@@ -1,0 +1,44 @@
+package trails
+
+// A Toolbox is a set of Tools exposed to the end user
+// in certain environments, notably, not in Production.
+// Generally, these are administrative tools that
+// simplify demonstrating features
+// which would otherwise require actions taken in many steps.
+type Toolbox []Tool
+
+// Filter returns a Toolbox after removing all Tools that cannot be rendered.
+// If none can be rendered, Filter returns a zero-value Toolbox.
+func (t Toolbox) Filter() Toolbox {
+	var n int
+	for _, tool := range t {
+		if tool.Render() {
+			t[n] = tool
+			n++
+		}
+	}
+
+	if n == 0 {
+		return make(Toolbox, 0)
+	}
+
+	return t[:n]
+}
+
+// A Tool is a set of actions grouped under a category.
+// A Tool may pertain to a part of the domain,
+// grouping actions touching similar models.
+type Tool struct {
+	Actions []ToolAction `json:"actions"`
+	Title   string       `json:"title"`
+}
+
+// Render asserts whether the Tool should be rendered.
+func (t Tool) Render() bool { return len(t.Actions) > 0 }
+
+// A ToolAction is a specific link the end user can follow
+// to execute the named action.
+type ToolAction struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}

--- a/toolbox_test.go
+++ b/toolbox_test.go
@@ -1,0 +1,20 @@
+package trails_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails"
+)
+
+func TestToolboxFilter(t *testing.T) {
+	// TODO
+	toolbox := make(trails.Toolbox, 1)
+	require.Len(t, toolbox.Filter(), 0)
+}
+
+func TestToolRender(t *testing.T) {
+	// TODO
+	var tool trails.Tool
+	require.False(t, tool.Render())
+}


### PR DESCRIPTION
## Problem statement
Adding a `Toolbox` to the data to be rendered is a little ungainly; see: [ex. 1](https://github.com/xy-planning-network/college-try/blob/220d23efe095dbc367ad817d3a8ceb252724b8d6/http/web/benefits_handler.go#L63) & [ex. 2](https://github.com/xy-planning-network/college-try/blob/220d23efe095dbc367ad817d3a8ceb252724b8d6/http/web/forms_handler.go#L19-L25).

## What this does
This PR moves the definitions of `Toolbox`, `Tool` and `ToolAction` found on [`college-try`](https://github.com/xy-planning-network/college-try/blob/master/domain/toolbox.go) to this repo. Check the docs for definitions of each of these.

This PR adds the `http/resp.Fn` `Toolbox` for injecting a toolbox into rendered data. If the `Toolbox` can be rendered, then it is nested under "props" with "toolbox" as its key. If other toolboxes are already present, the function merges them together. While this doesn't cover a current use case, it is consistent with many other functional options to merge rather than overwrite if more than one call to the option appears.

Right now, our use cases for toolboxes entail adding that data to a `map[string]any`. This PR is intentionally not solving the problem of how to use this new functional option with other datatypes - such as structs. Let's solve that problem when it arises.