### PR TITLE
Ranger loads default layout templates

### DIFF
--- a/http/resp/responder.go
+++ b/http/resp/responder.go
@@ -52,6 +52,8 @@ type Responder struct {
 	rootUrl *url.URL
 
 	templates struct {
+		additionalScripts string
+
 		// Root template to render when user is authenticated
 		authed string
 
@@ -64,6 +66,8 @@ type Responder struct {
 
 		// Vue template to render when rendering a Vue app
 		vue string
+
+		vueScripts string
 	}
 }
 
@@ -161,9 +165,9 @@ func (doer *Responder) Html(w http.ResponseWriter, r *http.Request, opts ...Fn) 
 		if err := populateUser(*doer, rr); err != nil {
 			return doer.handleHtmlError(w, r, err)
 		}
-
-		doer.parser.AddFn(template.CurrentUser(rr.user))
 	}
+
+	doer.parser.AddFn(template.CurrentUser(rr.user))
 
 	tmpl, err := doer.parser.Parse(rr.tmpls...)
 	if err != nil {

--- a/http/resp/responder_opt.go
+++ b/http/resp/responder_opt.go
@@ -12,6 +12,16 @@ import (
 // A ResponderOptFn is used when constructing a new Responder.
 type ResponderOptFn func(*Responder)
 
+// WithAdditionalScriptsTemplate sets the template identified by the filepath to use for rendering
+// alongside Authed and Unauthed templates.
+//
+// Authed and Unauthed requires this option.
+func WithAdditionalScriptsTemplate(fp string) func(*Responder) {
+	return func(d *Responder) {
+		d.templates.additionalScripts = fp
+	}
+}
+
 // WithAuthTemplate sets the template identified by the filepath to use for rendering
 // when a user is authenticated.
 //
@@ -90,5 +100,15 @@ func WithUnauthTemplate(fp string) func(*Responder) {
 func WithVueTemplate(fp string) func(*Responder) {
 	return func(d *Responder) {
 		d.templates.vue = fp
+	}
+}
+
+// WithVueTemplate sets the template identified by the filepath to use for rendering
+// additional scripts within a Vue client application.
+//
+// Vue requires this option.
+func WithVueScriptsTemplate(fp string) func(*Responder) {
+	return func(d *Responder) {
+		d.templates.vueScripts = fp
 	}
 }

--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -44,18 +44,15 @@ func Authed() Fn {
 			return err
 		}
 
-		if len(r.tmpls) > 0 {
-			if r.tmpls[0] == d.templates.authed {
-				return nil
-			}
-
-			if r.tmpls[0] == d.templates.unauthed {
-				r.tmpls[0] = d.templates.authed
-				return nil
+		var n int
+		for _, tmpl := range r.tmpls {
+			if tmpl != d.templates.unauthed {
+				r.tmpls[n] = tmpl
+				n++
 			}
 		}
 
-		r.tmpls = append([]string{d.templates.authed}, r.tmpls...)
+		r.tmpls = append([]string{d.templates.authed, d.templates.additionalScripts}, r.tmpls[:n]...)
 		return nil
 	}
 }
@@ -254,18 +251,15 @@ func Unauthed() Fn {
 			return fmt.Errorf("%w: no unauthed tmpl", ErrBadConfig)
 		}
 
-		if len(r.tmpls) > 0 {
-			if r.tmpls[0] == d.templates.unauthed {
-				return nil
-			}
-
-			if r.tmpls[0] == d.templates.authed {
-				r.tmpls[0] = d.templates.unauthed
-				return nil
+		var n int
+		for _, tmpl := range r.tmpls {
+			if tmpl != d.templates.authed {
+				r.tmpls[n] = tmpl
+				n++
 			}
 		}
 
-		r.tmpls = append([]string{d.templates.unauthed}, r.tmpls...)
+		r.tmpls = append([]string{d.templates.unauthed, d.templates.additionalScripts}, r.tmpls[:n]...)
 		return nil
 	}
 }
@@ -372,7 +366,7 @@ func Vue(entry string) Fn {
 		if d.templates.vue == "" || entry == "" {
 			return nil
 		}
-		if err := Tmpls(d.templates.vue)(d, r); err != nil {
+		if err := Tmpls(d.templates.vue, d.templates.vueScripts)(d, r); err != nil {
 			return err
 		}
 		// NOTE(dlk): ignore error since Vue does not require a User

--- a/http/resp/response_test.go
+++ b/http/resp/response_test.go
@@ -17,14 +17,17 @@ import (
 )
 
 type templatesTest struct {
-	authed   string
-	err      string
-	unauthed string
-	vue      string
+	additionalScripts string
+	authed            string
+	err               string
+	unauthed          string
+	vue               string
+	vueScripts        string
 }
 
 func TestAuthed(t *testing.T) {
-	expected := "authed.tmpl"
+	firstExpected := "authed.tmpl"
+	secondExpected := "additional.tmpl"
 	unauthed := "unauthed.tmpl"
 
 	tcs := []struct {
@@ -45,7 +48,7 @@ func TestAuthed(t *testing.T) {
 		},
 		{
 			name: "With-Auth",
-			d:    Responder{templates: templatesTest{authed: expected}},
+			d:    Responder{templates: templatesTest{authed: firstExpected, additionalScripts: secondExpected}},
 			r:    &Response{},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.ErrorIs(t, err, ErrNoUser)
@@ -54,45 +57,49 @@ func TestAuthed(t *testing.T) {
 		},
 		{
 			name:     "With-User-With-Auth",
-			d:        Responder{templates: templatesTest{authed: expected}},
+			d:        Responder{templates: templatesTest{authed: firstExpected, additionalScripts: secondExpected}},
 			loggedIn: true,
 			r:        &Response{},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Len(t, r.tmpls, 1)
-				require.Equal(t, expected, r.tmpls[0])
+				require.Len(t, r.tmpls, 2)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 		{
 			name:     "Tmpl-Authed",
-			d:        Responder{templates: templatesTest{authed: expected}},
+			d:        Responder{templates: templatesTest{authed: firstExpected, additionalScripts: secondExpected}},
 			loggedIn: true,
-			r:        &Response{tmpls: []string{expected}},
+			r:        &Response{tmpls: []string{firstExpected}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Len(t, r.tmpls, 1)
-				require.Equal(t, expected, r.tmpls[0])
+				require.Len(t, r.tmpls, 3)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 		{
 			name:     "Tmpl-Unauthed",
-			d:        Responder{templates: templatesTest{authed: expected, unauthed: unauthed}},
+			d:        Responder{templates: templatesTest{authed: firstExpected, additionalScripts: secondExpected, unauthed: unauthed}},
 			loggedIn: true,
 			r:        &Response{tmpls: []string{unauthed}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Len(t, r.tmpls, 1)
-				require.Equal(t, expected, r.tmpls[0])
+				require.Len(t, r.tmpls, 2)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 		{
 			name: "Tmpls",
-			d:    Responder{templates: templatesTest{authed: expected}},
+			d:    Responder{templates: templatesTest{authed: firstExpected, additionalScripts: secondExpected}},
 			r:    &Response{user: struct{}{}, tmpls: []string{"test.tmpl", "example.tmpl"}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Len(t, r.tmpls, 3)
-				require.Equal(t, expected, r.tmpls[0])
+				require.Len(t, r.tmpls, 4)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 	}
@@ -615,7 +622,8 @@ func TestToRoot(t *testing.T) {
 }
 
 func TestUnauthed(t *testing.T) {
-	expected := "unauthed.tmpl"
+	firstExpected := "unauthed.tmpl"
+	secondExpected := "additional.tmpl"
 	authed := "authed.tmpl"
 	tcs := []struct {
 		name   string
@@ -633,21 +641,24 @@ func TestUnauthed(t *testing.T) {
 		},
 		{
 			name: "With-Unauthed",
-			d:    Responder{templates: templatesTest{unauthed: expected}},
+			d:    Responder{templates: templatesTest{unauthed: firstExpected, additionalScripts: secondExpected}},
 			r:    &Response{},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Equal(t, expected, r.tmpls[0])
+				require.Len(t, r.tmpls, 2)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 		{
 			name: "With-Unauthed-Repeat",
-			d:    Responder{templates: templatesTest{unauthed: expected}},
-			r:    &Response{tmpls: []string{expected}},
+			d:    Responder{templates: templatesTest{unauthed: firstExpected, additionalScripts: secondExpected}},
+			r:    &Response{tmpls: []string{firstExpected}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Equal(t, expected, r.tmpls[0])
-				require.Len(t, r.tmpls, 1)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
+				require.Len(t, r.tmpls, 3)
 			},
 		},
 		{
@@ -660,22 +671,24 @@ func TestUnauthed(t *testing.T) {
 		},
 		{
 			name: "With-Authed-With-Unauthed",
-			d:    Responder{templates: templatesTest{authed: authed, unauthed: expected}},
+			d:    Responder{templates: templatesTest{authed: authed, unauthed: firstExpected, additionalScripts: secondExpected}},
 			r:    &Response{tmpls: []string{authed}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Equal(t, expected, r.tmpls[0])
-				require.Len(t, r.tmpls, 1)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
+				require.Len(t, r.tmpls, 2)
 			},
 		},
 		{
 			name: "With-Tmpls",
-			d:    Responder{templates: templatesTest{unauthed: expected}},
+			d:    Responder{templates: templatesTest{unauthed: firstExpected, additionalScripts: secondExpected}},
 			r:    &Response{tmpls: []string{"test.tmpl", "example.tmpl"}},
 			assert: func(t *testing.T, r *Response, err error) {
 				require.Nil(t, err)
-				require.Equal(t, expected, r.tmpls[0])
-				require.Len(t, r.tmpls, 3)
+				require.Len(t, r.tmpls, 4)
+				require.Equal(t, firstExpected, r.tmpls[0])
+				require.Equal(t, secondExpected, r.tmpls[1])
 			},
 		},
 	}

--- a/http/template/parse.go
+++ b/http/template/parse.go
@@ -36,11 +36,17 @@ func NewParser(fses []fs.FS, opts ...ParserOptFn) Parser {
 
 // Parse parses files found in the *Parse.fs with those functions provided previously.
 func (p *Parse) Parse(fps ...string) (*html.Template, error) {
-	for i, fp := range fps {
-		if fp == "" {
-			fps = append(fps[:i], fps[i+1:]...)
+	var n int
+	dupes := make(map[string]bool)
+	for _, fp := range fps {
+		if fp != "" && !dupes[fp] {
+			fps[n] = fp
+			dupes[fp] = true
+			n++
 		}
 	}
+
+	fps = fps[:n]
 
 	if len(fps) == 0 {
 		return nil, fmt.Errorf("%w", ErrNoFiles)

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -95,7 +95,6 @@ const (
 
 var (
 	defaultBaseURL = "http://" + DefaultHost + DefaultPort
-	setupLog       logger.Logger
 
 	//go:embed tmpl/*
 	tmpls embed.FS

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -57,12 +57,14 @@ const (
 	dbUserEnvVar     = "DATABASE_USER"
 
 	// Default HTML template files
-	defaultTmplDir      = "tmpl"
-	defaultErrTmpl      = defaultTmplDir + "/error.tmpl"
-	defaultLayoutDir    = defaultTmplDir + "/layout"
-	defaultAuthedTmpl   = defaultLayoutDir + "/authenticated_base.tmpl"
-	defaultUnauthedTmpl = defaultLayoutDir + "/unauthenticated_base.tmpl"
-	defaultVueTmpl      = defaultLayoutDir + "/vue.tmpl"
+	defaultTmplDir               = "tmpl"
+	defaultErrTmpl               = defaultTmplDir + "/error.tmpl"
+	defaultLayoutDir             = defaultTmplDir + "/layout"
+	defaultAdditionalScriptsTmpl = defaultLayoutDir + "/additional_scripts.tmpl"
+	defaultAuthedTmpl            = defaultLayoutDir + "/authenticated_base.tmpl"
+	defaultUnauthedTmpl          = defaultLayoutDir + "/unauthenticated_base.tmpl"
+	defaultVueTmpl               = defaultLayoutDir + "/vue.tmpl"
+	defaultVueScriptsTmpl        = defaultLayoutDir + "/vue_scripts.tmpl"
 
 	// Web server defaults
 	DefaultHost               = "localhost"
@@ -198,6 +200,7 @@ func defaultParser(env trails.Environment, url *url.URL, files fs.FS, m Metadata
 // defaultResponder configures the [*resp.Responder] to be used by http.Handlers.
 func defaultResponder(l logger.Logger, url *url.URL, p template.Parser, contact string) *resp.Responder {
 	args := []resp.ResponderOptFn{
+		resp.WithAdditionalScriptsTemplate(defaultAdditionalScriptsTmpl),
 		resp.WithAuthTemplate(defaultAuthedTmpl),
 		resp.WithContactErrMsg(fmt.Sprintf(session.ContactUsErr, contact)),
 		resp.WithErrTemplate(defaultErrTmpl),
@@ -206,6 +209,7 @@ func defaultResponder(l logger.Logger, url *url.URL, p template.Parser, contact 
 		resp.WithRootUrl(url.String()),
 		resp.WithUnauthTemplate(defaultUnauthedTmpl),
 		resp.WithVueTemplate(defaultVueTmpl),
+		resp.WithVueScriptsTemplate(defaultVueScriptsTmpl),
 	}
 
 	return resp.NewResponder(args...)

--- a/ranger/tmpl/layout/additional_scripts.tmpl
+++ b/ranger/tmpl/layout/additional_scripts.tmpl
@@ -1,0 +1,2 @@
+{{ define "additionalHeadScripts" }}{{ end }}
+{{ define "additionalBodyScripts" }}{{ end }}

--- a/ranger/tmpl/layout/authenticated_base.tmpl
+++ b/ranger/tmpl/layout/authenticated_base.tmpl
@@ -10,18 +10,22 @@
     <link rel="shortcut icon" href="/assets/favicon.ico">
     <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
 
+    {{ template "additionalHeadScripts" }}
+
     {{ if not isDevelopment }}
     {{ packTag "app" true }}
     {{ end }}
   </head>
 
   <body class="bg-gray-50">
+    {{ template "additionalBodyScripts" }}
+
     {{ template "pageContent" . }}
 
     <script type="text/javascript">
       window.Flashes = {{ .Flashes }};
     </script>
 
-    {{ template "scripts" . }}
+    {{ template "vue" . }}
   </body>
 </html>

--- a/ranger/tmpl/layout/authenticated_base.tmpl
+++ b/ranger/tmpl/layout/authenticated_base.tmpl
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+
+    <title>{{ metadata "title" }}</title>
+    <meta name="description" content="{{ metadata "description" }}">
+    <meta name="author" content="XYPN Technology">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="shortcut icon" href="/assets/favicon.ico">
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+
+    {{ if not isDevelopment }}
+    {{ packTag "app" true }}
+    {{ end }}
+  </head>
+
+  <body class="bg-gray-50">
+    {{ template "pageContent" . }}
+
+    <script type="text/javascript">
+      window.Flashes = {{ .Flashes }};
+    </script>
+
+    {{ template "scripts" . }}
+  </body>
+</html>

--- a/ranger/tmpl/layout/unauthenticated_base.tmpl
+++ b/ranger/tmpl/layout/unauthenticated_base.tmpl
@@ -10,18 +10,22 @@
     <link rel="shortcut icon" href="/assets/favicon.ico">
     <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
 
+    {{ template "additionalHeadScripts" }}
+
     {{ if not isDevelopment }}
     {{ packTag "app" true }}
     {{ end }}
   </head>
 
   <body class="bg-gray-50">
+    {{ template "additionalBodyScripts" }}
+
     {{ template "pageContent" . }}
 
     <script type="text/javascript">
       window.Flashes = {{ .Flashes }};
     </script>
 
-    {{ template "scripts" . }}
+    {{ template "vue" . }}
   </body>
 </html>

--- a/ranger/tmpl/layout/unauthenticated_base.tmpl
+++ b/ranger/tmpl/layout/unauthenticated_base.tmpl
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+
+    <title>{{ metadata "title" }}</title>
+    <meta name="description" content="{{ metadata "description" }}">
+    <meta name="author" content="XYPN Technology">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="shortcut icon" href="/assets/favicon.ico">
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+
+    {{ if not isDevelopment }}
+    {{ packTag "app" true }}
+    {{ end }}
+  </head>
+
+  <body class="bg-gray-50">
+    {{ template "pageContent" . }}
+
+    <script type="text/javascript">
+      window.Flashes = {{ .Flashes }};
+    </script>
+
+    {{ template "scripts" . }}
+  </body>
+</html>

--- a/ranger/tmpl/layout/vue.tmpl
+++ b/ranger/tmpl/layout/vue.tmpl
@@ -1,0 +1,22 @@
+{{ define "pageContent" }}
+  <div id="vue-app" v-cloak></div>
+{{ end }}
+
+{{ define "scripts" }}
+  <script type="text/javascript">
+    var InitialVueProps = {{ .Data.props }}
+  </script>
+
+  {{ packTag .Data.entry false }}
+
+  {{ if .Data.includeTockify }}
+    <script data-cfasync="false" data-tockify-script="embed" src="https://public.tockify.com/browser/embed.js"></script>
+  {{ end }}
+
+  {{ if .Data.includeCalendly }}
+    <!-- Calendly link widget begin -->
+    <link href="https://calendly.com/assets/external/widget.css" rel="stylesheet">
+    <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
+    <!-- Calendly link widget end -->
+  {{ end }}
+{{ end }}

--- a/ranger/tmpl/layout/vue.tmpl
+++ b/ranger/tmpl/layout/vue.tmpl
@@ -2,21 +2,12 @@
   <div id="vue-app" v-cloak></div>
 {{ end }}
 
-{{ define "scripts" }}
+{{ define "vue" }}
   <script type="text/javascript">
     var InitialVueProps = {{ .Data.props }}
   </script>
 
   {{ packTag .Data.entry false }}
 
-  {{ if .Data.includeTockify }}
-    <script data-cfasync="false" data-tockify-script="embed" src="https://public.tockify.com/browser/embed.js"></script>
-  {{ end }}
-
-  {{ if .Data.includeCalendly }}
-    <!-- Calendly link widget begin -->
-    <link href="https://calendly.com/assets/external/widget.css" rel="stylesheet">
-    <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
-    <!-- Calendly link widget end -->
-  {{ end }}
+  {{ template "vueScripts" . }}
 {{ end }}

--- a/ranger/tmpl/layout/vue_scripts.tmpl
+++ b/ranger/tmpl/layout/vue_scripts.tmpl
@@ -1,0 +1,1 @@
+{{ define "vueScripts" }}{{ end }}


### PR DESCRIPTION
## Problem statement
`ranger` provides 2 [`fs.FS`](https://pkg.go.dev/io/fs#FS) to `http/template` in order to parse its own embedded files and those provided by the application (with the latter overriding any default templates in ranger). The initial use case was to ensure an error page is made as a backstop for unruly `*http/resp.Responder.Html` calls. We can push this paradigm further by including the layout templates every project uses.

## What this does
This PR creates a new `ranger/tmpl/layout` dir with 5 files, more on those files below. By doing this, development can begin immediately without needing to copy these files from another repo. Only when some additional markup diverging from the minimal defaults is needed would someone begin developing their own layout templates.
- `unauthenticated_base.tmpl` which renders in `http/resp.Unauthed` calls
- `authenticated_base.tmpl` which renders in `http/resp.Authed` calls
- `additional_scripts.tmpl` which injects `additionalHeadScripts` and `additionalBodyScripts` into the above 2 templates
- `vue.tmpl` which renders in `http/resp.Vue` calls
- `vue_scripts.tmpl` which injects `vueScripts` into the above template

For `college-try`, `second-child` & `wall-to-wall`, `additional_scripts.tmpl` would be need to be created in order to throw in all the 3rd party scripts those applications have. In `college-try`'s case, it needs `vueScripts` to throw in a bit more once the Vue app completes loading.

NB: it's important to recall that overriding any or all of the above files means (1) placing those files in a directory called `tmpl/layout`, (2) embedding the directory in your application, and (3) exposing that embedded `fs.FS` in app startup in `ranger.Config`.