### PR TITLE
replaces logger.Logger in middleware.LogRequest with slog.Logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/joho/godotenv v1.4.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20230419192730-864b3d6c5c2c
+	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/gorm v1.21.11
@@ -40,8 +42,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -308,6 +308,8 @@ golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20230419192730-864b3d6c5c2c h1:HDdYQYKOkvJT/Plb5HwJJywTVyUnIctjQm6XSnZ/0CY=
+golang.org/x/exp v0.0.0-20230419192730-864b3d6c5c2c/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -350,8 +352,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/http/middleware/get_ip_address.go
+++ b/http/middleware/get_ip_address.go
@@ -10,8 +10,6 @@ import (
 	"github.com/xy-planning-network/trails"
 )
 
-const IpAddrCtxKey = "trails/middleware/ip-address" // TODO(dlk): change to key provided by app?
-
 // An ipRange is a range of IP addresses.
 type ipRange struct {
 	start net.IP

--- a/http/middleware/log_request.go
+++ b/http/middleware/log_request.go
@@ -66,7 +66,7 @@ func LogRequest(handler slog.Handler) Adapter {
 
 // A LogRequestRecord represents the fields that a LogRequest
 type LogRequestRecord struct {
-	BodySize       int    `json:"responseBodySize"`
+	BodySize       int    `json:"bodySize"`
 	Duration       int64  `json:"duration"`
 	Host           string `json:"host"`
 	ID             string `json:"id"`
@@ -75,8 +75,8 @@ type LogRequestRecord struct {
 	Path           string `json:"path"`
 	Protocol       string `json:"protocol"`
 	Referrer       string `json:"referrer"`
-	ReqContentLen  int    `json:"requestContentLength"`
-	ReqContentType string `json:"requestContentType"`
+	ReqContentLen  int    `json:"contentLength"`
+	ReqContentType string `json:"contentType"`
 	Scheme         string `json:"scheme"`
 	Status         int    `json:"status"`
 	URI            string `json:"uri"`
@@ -98,7 +98,7 @@ func newRecord(w *requestLogger, r *http.Request) LogRequestRecord {
 	ip, _ := r.Context().Value(trails.IpAddrKey).(string)
 
 	return LogRequestRecord{
-		BodySize:       w.bodysize,
+		BodySize:       w.bodySize,
 		Host:           r.Host,
 		ID:             id,
 		IPAddr:         ip,
@@ -125,9 +125,9 @@ func (r LogRequestRecord) attrs() []slog.Attr {
 		slog.String("path", r.Path),
 		slog.String("protocol", r.Protocol),
 		slog.String("referrer", r.Referrer),
-		slog.Int("requestContentLength", r.ReqContentLen),
-		slog.String("requestContentType", r.ReqContentType),
-		slog.Int("responseBodySize", r.BodySize),
+		slog.Int("contentLength", r.ReqContentLen),
+		slog.String("contentType", r.ReqContentType),
+		slog.Int("bodySize", r.BodySize),
 		slog.String("scheme", r.Scheme),
 		slog.Int("status", r.Status),
 		slog.String("uri", r.URI),
@@ -138,7 +138,7 @@ func (r LogRequestRecord) attrs() []slog.Attr {
 type requestLogger struct {
 	http.ResponseWriter
 	status   int
-	bodysize int
+	bodySize int
 }
 
 func (rl *requestLogger) Header() http.Header { return rl.ResponseWriter.Header() }
@@ -149,7 +149,7 @@ func (rl *requestLogger) Header() http.Header { return rl.ResponseWriter.Header(
 func (rl *requestLogger) Unwrap() http.ResponseWriter { return rl.ResponseWriter }
 func (rl *requestLogger) Write(b []byte) (int, error) {
 	size, err := rl.ResponseWriter.Write(b)
-	rl.bodysize += size
+	rl.bodySize += size
 
 	return size, err
 

--- a/http/middleware/log_request.go
+++ b/http/middleware/log_request.go
@@ -2,44 +2,167 @@ package middleware
 
 import (
 	"net/http"
-	"strings"
+	"net/url"
+	"strconv"
+	"time"
 
-	"github.com/xy-planning-network/trails/logger"
+	"github.com/xy-planning-network/trails"
+	"golang.org/x/exp/slog"
 )
 
-// LogRequest logs the request's method, requested URL, and originating IP address
-// using the enclosed implementation of logger.Logger.
+const (
+	passwordParam     = "password"
+	contentLenHeader  = "Content-Length"
+	contentTypeHeader = "Content-Type"
+	referrerHeader    = "Referrer"
+	userAgentHeader   = "User-Agent"
+)
+
+// LogRequest logs the a LogRequestRecord using the provided handler.
 //
-// LogRequest scrubs the values for the following keys:
+// For the LogRequestRecord.URI, LogRequest masks query params matching these keys with trails.LogMaskVal:
 // - password
 //
-// if logger.Logger is nil, NoopAdapter returns and this middleware does nothing.
-func LogRequest(ls logger.Logger) Adapter {
-	if ls == nil {
+// If handler is nil, NoopAdapter returns and this middleware does nothing.
+func LogRequest(handler slog.Handler) Adapter {
+	if handler == nil {
 		return NoopAdapter
 	}
 
+	// NOTE(dlk): add constant values to include on every message here
+	ls := slog.New(handler.WithAttrs([]slog.Attr{
+		{Key: trails.LogKindKey, Value: trails.HTTPLogKind},
+	}))
+
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			uri := r.URL.Path
-			q := r.URL.Query()
-			if val := q.Get("password"); val != "" {
-				q.Set("password", "xxxxxxx")
-			}
+			start := time.Now()
 
-			query := q.Encode()
-			if query != "" {
-				uri += "?" + q.Encode()
-			}
+			writer := &requestLogger{ResponseWriter: w, status: http.StatusOK}
+			h.ServeHTTP(writer, r)
 
-			strs := []string{r.Method, uri}
-			val := r.Context().Value(IpAddrCtxKey)
-			if val != nil {
-				strs = append([]string{val.(string)}, strs...)
-			}
+			end := time.Since(start).Milliseconds()
 
-			ls.Info(strings.Join(strs, " "), nil)
-			h.ServeHTTP(w, r)
+			rec := newRecord(writer, r)
+			rec.Duration = end
+
+			var msg string // NOTE(dlk): no message for now.
+
+			// NOTE(dlk): LogAttrs is not the standard method to use,
+			// but we know we only have a []slog.Attr to report,
+			// so let's leverage it.
+			//
+			// TODO(dlk): using r.Context() may not be appropriate.
+			// Unfortunately, outside of configuring a slog.Handler to pull
+			// values from a context.Context into slog.Attr,
+			// contexts appear to not be used by slog.
+			// This includes not watching for cancellations.
+			// The ranger.Context may be the best fit for this.
+			// We'll reassess when slog makes into a Go version.
+			ls.LogAttrs(r.Context(), slog.LevelInfo, msg, rec.attrs()...)
 		})
+	}
+}
+
+// A LogRequestRecord represents the fields that a LogRequest
+type LogRequestRecord struct {
+	BodySize       int    `json:"responseBodySize"`
+	Duration       int64  `json:"duration"`
+	Host           string `json:"host"`
+	ID             string `json:"id"`
+	IPAddr         string `json:"remoteAddr"`
+	Method         string `json:"method"`
+	Path           string `json:"path"`
+	Protocol       string `json:"protocol"`
+	Referrer       string `json:"referrer"`
+	ReqContentLen  int    `json:"requestContentLength"`
+	ReqContentType string `json:"requestContentType"`
+	Scheme         string `json:"scheme"`
+	Status         int    `json:"status"`
+	URI            string `json:"uri"`
+	UserAgent      string `json:"userAgent"`
+}
+
+// newRecord constructs a record from the values availabe in w & r.
+func newRecord(w *requestLogger, r *http.Request) LogRequestRecord {
+	// TODO(dlk): if there's a compelling reason for constructing a LogRequestRecord
+	// outside this package, this constructor and LogRequestRecord.attrs could be exported.
+	uri := new(url.URL)
+	*uri = *r.URL
+	q := r.URL.Query()
+	mask(q, passwordParam)
+	uri.RawQuery = q.Encode()
+
+	contLen, _ := strconv.Atoi(r.Header.Get(contentLenHeader))
+	id, _ := r.Context().Value(trails.RequestIDKey).(string)
+	ip, _ := r.Context().Value(trails.IpAddrKey).(string)
+
+	return LogRequestRecord{
+		BodySize:       w.bodysize,
+		Host:           r.Host,
+		ID:             id,
+		IPAddr:         ip,
+		Method:         r.Method,
+		Path:           r.URL.Path,
+		Protocol:       r.Proto,
+		Referrer:       r.Header.Get(referrerHeader),
+		ReqContentLen:  contLen,
+		ReqContentType: r.Header.Get(contentTypeHeader),
+		Scheme:         r.URL.Scheme,
+		Status:         w.status,
+		URI:            uri.RequestURI(),
+		UserAgent:      r.Header.Get(userAgentHeader),
+	}
+}
+
+func (r LogRequestRecord) attrs() []slog.Attr {
+	return []slog.Attr{
+		slog.Int64("duration", r.Duration),
+		slog.String("host", r.Host),
+		slog.String("id", r.ID),
+		slog.String("remoteAddr", r.IPAddr),
+		slog.String("method", r.Method),
+		slog.String("path", r.Path),
+		slog.String("protocol", r.Protocol),
+		slog.String("referrer", r.Referrer),
+		slog.Int("requestContentLength", r.ReqContentLen),
+		slog.String("requestContentType", r.ReqContentType),
+		slog.Int("responseBodySize", r.BodySize),
+		slog.String("scheme", r.Scheme),
+		slog.Int("status", r.Status),
+		slog.String("uri", r.URI),
+		slog.String("userAgent", r.UserAgent),
+	}
+}
+
+type requestLogger struct {
+	http.ResponseWriter
+	status   int
+	bodysize int
+}
+
+func (rl *requestLogger) Header() http.Header { return rl.ResponseWriter.Header() }
+
+// Unwrap exposes the underlying http.ResponseWriter.
+//
+// NOTE(dlk): include in order to simplify using [net/http.ResponseController].
+func (rl *requestLogger) Unwrap() http.ResponseWriter { return rl.ResponseWriter }
+func (rl *requestLogger) Write(b []byte) (int, error) {
+	size, err := rl.ResponseWriter.Write(b)
+	rl.bodysize += size
+
+	return size, err
+
+}
+
+func (rl *requestLogger) WriteHeader(code int) {
+	rl.status = code
+	rl.ResponseWriter.WriteHeader(code)
+}
+
+// mask replaces all instances of key in q with trails.LogMaskVal.
+func mask(q url.Values, key string) {
+	if val := q.Get(key); val != "" {
+		q.Set(key, trails.LogMaskVal)
 	}
 }

--- a/http/middleware/log_request_test.go
+++ b/http/middleware/log_request_test.go
@@ -1,7 +1,9 @@
 package middleware_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +11,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails"
 	"github.com/xy-planning-network/trails/http/middleware"
+	"golang.org/x/exp/slog"
 )
 
 func TestLogRequest(t *testing.T) {
@@ -20,47 +24,109 @@ func TestLogRequest(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%p", middleware.NoopAdapter), fmt.Sprintf("%p", actual))
 
 	// Arrange
+	ip := "192.168.0.0"
+	testID := "test-id"
+	useragent := "trails/test"
+	content := "very-secret/encoding; shhh"
+	referrer := "example.com/referrer"
+	respBody := "test"
+	newExpected := func(expected middleware.LogRequestRecord) middleware.LogRequestRecord {
+		expected.BodySize = len(respBody)
+		expected.Host = "example.com"
+		expected.ID = testID
+		expected.Protocol = "HTTP/1.1"
+		expected.Referrer = referrer
+		expected.ReqContentType = content
+		expected.Status = 200
+		expected.UserAgent = useragent
+
+		return expected
+	}
+
 	tcs := []struct {
 		name     string
 		method   string
 		ip       string
 		url      *url.URL
-		expected string
+		expected middleware.LogRequestRecord
 	}{
-		{"Zero-Value", http.MethodGet, "", &url.URL{Path: "/"}, "GET /"},
-		{"With-IP", http.MethodPost, "127.0.0.1", &url.URL{Path: "/"}, "127.0.0.1 POST /"},
+		{
+			"Zero-Value",
+			http.MethodGet,
+			"",
+			&url.URL{Path: "/"},
+			newExpected(middleware.LogRequestRecord{
+				Method: http.MethodGet,
+				Path:   "/",
+				URI:    "/",
+			}),
+		},
+		{
+			"With-IP",
+			http.MethodPost,
+			ip,
+			&url.URL{Path: "/"},
+			newExpected(middleware.LogRequestRecord{
+				IPAddr: ip,
+				Method: http.MethodPost,
+				Path:   "/",
+				URI:    "/",
+			}),
+		},
 		{
 			"With-Query-Params",
 			http.MethodPut,
-			"0.0.0.0",
+			ip,
 			&url.URL{Path: "/hitting/the/trails", RawQuery: "param=true"},
-			"0.0.0.0 PUT /hitting/the/trails?param=true",
+			newExpected(middleware.LogRequestRecord{
+				IPAddr: ip,
+				Method: http.MethodPut,
+				Path:   "/hitting/the/trails",
+				URI:    "/hitting/the/trails?param=true",
+			}),
 		},
 		{
 			"With-Query-Params-Hid",
 			http.MethodGet,
-			"192.168.0.0",
-			&url.URL{Path: "/", RawQuery: "param=true&password=hunter2"},
-			"192.168.0.0 GET /?param=true&password=xxxxxxx",
+			ip,
+			&url.URL{Scheme: "http", Path: "/", RawQuery: "param=true&password=hunter2"},
+			newExpected(middleware.LogRequestRecord{
+				IPAddr: ip,
+				Method: http.MethodGet,
+				Path:   "/",
+				URI:    "/?param=true&password=" + trails.LogMaskVal,
+				Scheme: "http",
+			}),
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			l := newLogger()
+			b := new(bytes.Buffer)
+			h := slog.NewJSONHandler(b)
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(tc.method, tc.url.String(), nil)
+			r := httptest.NewRequest(tc.method, tc.url.String(), new(bytes.Reader))
+			r = r.Clone(context.WithValue(r.Context(), trails.RequestIDKey, "test-id"))
+
+			r.Header.Set("User-Agent", useragent)
+			r.Header.Set("Content-Type", content)
+			r.Header.Set("Referrer", referrer)
 
 			if tc.ip != "" {
-				r = r.Clone(context.WithValue(r.Context(), middleware.IpAddrCtxKey, tc.ip))
+				r = r.Clone(context.WithValue(r.Context(), trails.IpAddrKey, tc.ip))
 			}
 
+			var actual middleware.LogRequestRecord
+
 			// Act
-			middleware.LogRequest(l)(noopHandler()).ServeHTTP(w, r)
+			middleware.LogRequest(h)(http.HandlerFunc(func(wx http.ResponseWriter, rx *http.Request) {
+				fmt.Fprint(wx, "test")
+			})).ServeHTTP(w, r)
 
 			// Assert
-			require.Equal(t, tc.expected, l.String())
+			require.Nil(t, json.Unmarshal(b.Bytes(), &actual))
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/log.go
+++ b/log.go
@@ -1,0 +1,19 @@
+package trails
+
+import "golang.org/x/exp/slog"
+
+const (
+	LogKindKey = "kind"
+	LogMaskVal = "xxxxxx"
+)
+
+var (
+	AppLogKind    = slog.StringValue("app")
+	HTTPLogKind   = slog.StringValue("http")
+	WorkerLogKind = slog.StringValue("worker")
+
+	// MaskedLogValue is a convenience [golang.org/x/exp/slog.Value]
+	// to be used in implementations of [golang.org/x/exp/slog.LogValuer]
+	// to hide sensitive data from log messages.
+	MaskedLogValue = slog.StringValue(LogMaskVal)
+)

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -55,6 +55,10 @@ func New[U RangerUser](cfg Config[U]) (*Ranger, error) {
 		return nil, err
 	}
 
+	if cfg.logoutput == nil {
+		cfg.logoutput = os.Stdout
+	}
+
 	r := new(Ranger)
 
 	// Setup initial configuration
@@ -98,7 +102,7 @@ func New[U RangerUser](cfg Config[U]) (*Ranger, error) {
 		mws,
 		middleware.RequestID(),
 		middleware.InjectIPAddress(),
-		middleware.LogRequest(r.Logger),
+		middleware.LogRequest(defaultSloggerHandler(r.env, cfg.logoutput)),
 		middleware.InjectSession(r.sessions),
 		middleware.CurrentUser(r.Responder, userstore),
 	)


### PR DESCRIPTION
## Problem statement
There are 2 problems this PR moves the needle towards solving.

1. Including more data in HTTP router handling logs. Doubling down on AWS, we want to know more about how HTTP requests are handled in our application and be able to trace those requests more reliably. As of now, our implementation of this functionality in the `LogRequest` middleware provides limited information.

2. Our logging lacks ergonomics. With a [`slog`](https://pkg.go.dev/golang.org/x/exp/slog) accepted for implementation in the std lib, let's jump on board.

## What this does
This PR makes 3 major changes:
1. It moves `LogRequest` to a "post-response" middleware. Some of the data we want to record can only be known after the request is handled (e.g., response status code), so must log the message after the application completes handling the request.

2. It includes data from the `*http.Request` and `http.ResponseWriter` as requested in [this Notion ticket](https://www.notion.so/xylabs/reLogging-refactor-984c89157f5f4458b06c5c08eafcd5de?pvs=4). This fills out the picture of what the request/response lifecycle looked like.

3. It uses `slog` in place of `trails/logger.Logger` for writing messages. This wasn't strictly necessary for problem 1 above, but this looked like a good, small use case showing some of the breadth of functionality in `slog`. Originally, I knocked out 1 by tab-delimiting the fields in the message, but the amount of new data made the message itself ungainly when compared to key-value based messages.
    - ⚠️ We ought to expect the API for `slog`to change before final acceptance into the std lib. We need not keep up with every iota, though. An incoming proposal PR will show how we'll take a two step process replacing `trails/logger` with `slog` where that first step will limit direct exposure to the `slog` API in our applications. ⚠️ 
