### PR TITLE
Remove ranger.Config.Shutdown

### DIFF
--- a/logger/sentry.go
+++ b/logger/sentry.go
@@ -1,7 +1,9 @@
 package logger
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/xy-planning-network/trails"
@@ -103,6 +105,12 @@ func (sl *SentryLogger) send(level sentry.Level, ctx *LogContext) {
 
 		sentry.CaptureException(ctx.Error)
 	})
+}
+
+// FlushSentry is a ranger.ShutdownFn that calls sentry.Flush on app shutdown.
+func FlushSentry(_ context.Context) error {
+	sentry.Flush(2 * time.Second)
+	return nil
 }
 
 // skipBackFrames removes stacktrace frames from the *sentry.Event

--- a/ranger/config.go
+++ b/ranger/config.go
@@ -25,10 +25,6 @@ type Config[U RangerUser] struct {
 	// Migrations are a list of DB migrations to run upon DB successful connection.
 	Migrations []postgres.Migration
 
-	// Shutdowns are a series of functions that ought to be called before *Ranger
-	// stops handling HTTP requests.
-	Shutdowns []ShutdownFn
-
 	mockdb    *postgres.MockDatabaseService
 	logoutput io.Writer
 }

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -65,6 +65,10 @@ func New[U RangerUser](cfg Config[U]) (*Ranger, error) {
 	// Setup initial configuration
 	r.env = trails.EnvVarOrEnv(environmentEnvVar, trails.Development)
 	r.Logger = defaultAppLogger(r.env, cfg.logoutput)
+	if _, ok := r.Logger.(*logger.SentryLogger); ok {
+		r.shutdowns = append(r.shutdowns, logger.FlushSentry)
+	}
+
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 
 	if cfg.mockdb == nil {


### PR DESCRIPTION
There is no need for flexibility with shutting down plugins, etc. as the only use case is Sentry. Instead, this PR brings in `logger.FlushSentry` and adds it to `*Ranger.shutdowns` when a `*logger.SentryLogger` is at hand.