### PR TITLE
Ensure maintenance mode handler responds properly with 503

### DIFF
--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -308,7 +308,7 @@ func newMaintRanger[U RangerUser](r *Ranger, cfg Config[U]) *Ranger {
 	r.Router = router.NewRouter(r.env.String())
 	r.Router.OnEveryRequest(mws...)
 
-	r.Router.CatchAll(maintModeHandler(
+	r.Router.CatchAll(MaintModeHandler(
 		defaultParser(r.env, r.url, cfg.FS, r.metadata),
 		r.Logger,
 		r.metadata.Contact),
@@ -321,9 +321,10 @@ func newMaintRanger[U RangerUser](r *Ranger, cfg Config[U]) *Ranger {
 	return r
 }
 
-func maintModeHandler(p *template.Parser, l logger.Logger, contact string) http.HandlerFunc {
+func MaintModeHandler(p *template.Parser, l logger.Logger, contact string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Add("Retry-After", "300")
+		w.Header().Add("Retry-After", "600")
+		w.WriteHeader(http.StatusServiceUnavailable)
 
 		tmpl, err := p.Parse("tmpl/maintenance.tmpl")
 		if err != nil {

--- a/ranger/ranger_test.go
+++ b/ranger/ranger_test.go
@@ -1,0 +1,50 @@
+package ranger_test
+
+import (
+	"bytes"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails/http/template"
+	tt "github.com/xy-planning-network/trails/http/template/templatetest"
+	"github.com/xy-planning-network/trails/logger"
+	"github.com/xy-planning-network/trails/ranger"
+	"golang.org/x/exp/slog"
+)
+
+func TestMaintModeHandler(t *testing.T) {
+	// Arrange
+	b := new(bytes.Buffer)
+	l := logger.New(slog.New(slog.HandlerOptions{AddSource: true}.NewTextHandler(b)))
+	p := template.NewParser([]fs.FS{tt.NewMockFS(tt.NewMockFile("", nil))})
+	handler := ranger.MaintModeHandler(p, l, "test@example.com")
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	// Act + Assert
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Equal(t, "600", rr.Result().Header.Get("Retry-After"))
+	require.Equal(t, "", rr.Body.String())
+
+	// Arrange -- Test POST w/ route & tmpl content
+	msg := "Sorry for the inconvenience"
+	p = template.NewParser([]fs.FS{tt.NewMockFS(tt.NewMockFile("tmpl/maintenance.tmpl", []byte(msg)))})
+	handler = ranger.MaintModeHandler(p, l, "test@example.com")
+	req, err = http.NewRequest("POST", "/maint-mode-test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Act + Assert
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Equal(t, "600", rr.Result().Header.Get("Retry-After"))
+	require.Equal(t, msg, rr.Body.String())
+}


### PR DESCRIPTION
The maintenance mode handler was returning a `200 OK` response. This PR:

- Changes the response code to `503`
- Bumps the `retry-after` header to `600` (I figured that for our typical use-case of DB maintenance, `300` might be a bit low -- but I guess it's all pretty arbitrary)
- Adds a test