### PR TITLE
Configures gorm logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
 [._]sw[a-p]
+
+# Mac OS auto-generated files
+.DS_store

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -145,7 +145,7 @@ func NewPostgresConfig(env trails.Environment) *postgres.CxnConfig {
 // using default configuration environment variables
 // and runs the list of [postgres.Migration] passed in.
 func defaultDB(env trails.Environment, list []postgres.Migration) (postgres.DatabaseService, error) {
-	db, err := postgres.Connect(NewPostgresConfig(env), list)
+	db, err := postgres.Connect(NewPostgresConfig(env), list, env)
 	if err != nil {
 		return nil, err
 	}
@@ -256,8 +256,8 @@ func newSlogger(kind slog.Value, env trails.Environment, out io.Writer) *slog.Lo
 //
 //   - "env"
 //   - "metadata"
-//   	- "description" returns the value set by the APP_DESCRIPTION env var
-//   	- "title" returns the value set by the APP_TITLE env var
+//   - "description" returns the value set by the APP_DESCRIPTION env var
+//   - "title" returns the value set by the APP_TITLE env var
 //   - "nonce"
 //   - "rootUrl"
 //   - "packTag"


### PR DESCRIPTION
I debated passing the config through ranger or something else so that it could be completely overrode, but opted to simply remove not found errors and remove color outside of dev. This creates the minimal amount of changes from what we have now while also not allowing more configuration we don't have an immediate use case for.