### PR TITLE
Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - run: go test ./... --cover -v -race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.4"
+          go-version: "1.21"
 
       - run: go test ./... --cover -v -race

--- a/environment.go
+++ b/environment.go
@@ -1,13 +1,12 @@
 package trails
 
 import (
+	"log/slog"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 // An Environment is a different context in which a trails app operates.
@@ -137,8 +136,8 @@ func EnvVarOrInt(key string, def int) int {
 }
 
 // EnvVarOrLogLevel gets the environment variable for the provided key,
-// creates a [golang.org/x/exp/slog.Level] from the retrieved value,
-// or returns the provided default [golang.org/x/exp/slog.Level].
+// creates a [log/slog.Level] from the retrieved value,
+// or returns the provided default [log/slog.Level].
 func EnvVarOrLogLevel(key string, def slog.Level) slog.Level {
 	val := os.Getenv(key)
 	if val == "" {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	gorm.io/driver/postgres v1.0.8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xy-planning-network/trails
 
-go 1.20
+go 1.21
 
 require (
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/joho/godotenv v1.4.0
 	github.com/stretchr/testify v1.7.0
-	github.com/xy-planning-network/tint v0.0.0-20230807192211-11572c81efcc
+	github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -277,10 +278,10 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xy-planning-network/tint v0.0.0-20230425211519-12ff4bc615ea h1:l4+JDKmmIMkeO46UkAtEgdgrCVaO+zvbJAdc866pGbw=
-github.com/xy-planning-network/tint v0.0.0-20230425211519-12ff4bc615ea/go.mod h1:J50hEZVG8Uql9chR0C9sSskXNc57qUcjxIJIYPoXuqk=
 github.com/xy-planning-network/tint v0.0.0-20230807192211-11572c81efcc h1:QJPRSMqTRKeby/cgSsdCF0FQw/gu/uPJ5g1QIPOf+/k=
 github.com/xy-planning-network/tint v0.0.0-20230807192211-11572c81efcc/go.mod h1:gXplhQH0YZUxNZDGxDKFtKar0hFKVOvVyRmKf2iLCHs=
+github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c h1:x0mkXGJf4xwDeX1gktLxDaqSl506nijT1HGLTrEhqCw=
+github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c/go.mod h1:3WvgdEVrP7dBh5icrj6pTsB0U9G31jUClJ3r78DYjtE=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
@@ -307,8 +308,6 @@ golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20230420155640-133eef4313cb h1:rhjz/8Mbfa8xROFiH+MQphmAmgqRM0bOMnytznhWEXk=
-golang.org/x/exp v0.0.0-20230420155640-133eef4313cb/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -354,6 +353,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/go.sum
+++ b/go.sum
@@ -76,9 +76,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -278,8 +277,6 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xy-planning-network/tint v0.0.0-20230807192211-11572c81efcc h1:QJPRSMqTRKeby/cgSsdCF0FQw/gu/uPJ5g1QIPOf+/k=
-github.com/xy-planning-network/tint v0.0.0-20230807192211-11572c81efcc/go.mod h1:gXplhQH0YZUxNZDGxDKFtKar0hFKVOvVyRmKf2iLCHs=
 github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c h1:x0mkXGJf4xwDeX1gktLxDaqSl506nijT1HGLTrEhqCw=
 github.com/xy-planning-network/tint v0.0.0-20230906200307-662ca545427c/go.mod h1:3WvgdEVrP7dBh5icrj6pTsB0U9G31jUClJ3r78DYjtE=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
@@ -308,8 +305,6 @@ golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -351,9 +346,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/http/middleware/log_request.go
+++ b/http/middleware/log_request.go
@@ -1,13 +1,13 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/xy-planning-network/trails"
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/http/middleware/log_request_test.go
+++ b/http/middleware/log_request_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xy-planning-network/trails"
 	"github.com/xy-planning-network/trails/http/middleware"
-	"golang.org/x/exp/slog"
 )
 
 func TestLogRequest(t *testing.T) {

--- a/http/resp/responder_opt_test.go
+++ b/http/resp/responder_opt_test.go
@@ -3,13 +3,13 @@ package resp
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xy-planning-network/trails/http/session"
 	"github.com/xy-planning-network/trails/logger"
-	"golang.org/x/exp/slog"
 )
 
 func TestResponderWithAuthTemplate(t *testing.T) {

--- a/http/resp/responder_test.go
+++ b/http/resp/responder_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,7 +18,6 @@ import (
 	"github.com/xy-planning-network/trails/http/session"
 	tt "github.com/xy-planning-network/trails/http/template/templatetest"
 	"github.com/xy-planning-network/trails/logger"
-	"golang.org/x/exp/slog"
 )
 
 type testFn func(*testing.T, *httptest.ResponseRecorder, *http.Request, error)

--- a/log.go
+++ b/log.go
@@ -3,7 +3,7 @@ package trails
 import (
 	"strings"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/logger/context.go
+++ b/logger/context.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/xy-planning-network/trails"
-	"golang.org/x/exp/slog"
 )
 
 var (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,14 +2,13 @@ package logger
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path"
 	"regexp"
 	"runtime"
 	"strconv"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 const (
@@ -53,13 +52,13 @@ type Logger interface {
 	Warn(msg string, ctx *LogContext)
 }
 
-// TrailsLogger implements [Logger] using [golang.org/x/exp/slog.Logger].
+// TrailsLogger implements [Logger] using [log/slog.Logger].
 type TrailsLogger struct {
 	l    *slog.Logger
 	skip int
 }
 
-// New constructs a Logger using [golang.org/x/exp/slog.Logger].
+// New constructs a Logger using [log/slog.Logger].
 func New(log *slog.Logger) Logger { return &TrailsLogger{l: log} }
 
 func (l *TrailsLogger) AddSkip(i int) Logger {

--- a/logger/sentry.go
+++ b/logger/sentry.go
@@ -3,11 +3,11 @@ package logger
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/xy-planning-network/trails"
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -23,7 +24,6 @@ import (
 	"github.com/xy-planning-network/trails/http/template"
 	"github.com/xy-planning-network/trails/logger"
 	"github.com/xy-planning-network/trails/postgres"
-	"golang.org/x/exp/slog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -168,7 +168,7 @@ func defaultAppLogger(env trails.Environment, output io.Writer) logger.Logger {
 	return l
 }
 
-// defaultHTTPLogger constructs a [*golang.org/x/exp/slog.Logger] for use in HTTP router logging.
+// defaultHTTPLogger constructs a [*log/slog.Logger] for use in HTTP router logging.
 func defaultHTTPLogger(env trails.Environment, output io.Writer) *slog.Logger {
 	sl := newSlogger(trails.HTTPLogKind, env, output)
 	sl.Debug("setting up HTTP router logger")
@@ -176,7 +176,7 @@ func defaultHTTPLogger(env trails.Environment, output io.Writer) *slog.Logger {
 	return sl
 }
 
-// defaultWorkerLogger constructs a [*golang.org/x/exp/slog.Logger] for use in Faktory worker logging.
+// defaultWorkerLogger constructs a [*log/slog.Logger] for use in Faktory worker logging.
 func defaultWorkerLogger(env trails.Environment) logger.Logger {
 	slogger := newSlogger(trails.WorkerLogKind, env, os.Stdout)
 	l := logger.New(slogger)
@@ -189,7 +189,7 @@ func defaultWorkerLogger(env trails.Environment) logger.Logger {
 	return l
 }
 
-// newSlogger toggles contructing the specific [*golang.org/x/exp/slog.Logger]
+// newSlogger toggles contructing the specific [*log/slog.Logger]
 // from the given parameters.
 func newSlogger(kind slog.Value, env trails.Environment, out io.Writer) *slog.Logger {
 	lvl := new(slog.LevelVar)

--- a/ranger/ranger_test.go
+++ b/ranger/ranger_test.go
@@ -3,6 +3,7 @@ package ranger_test
 import (
 	"bytes"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	tt "github.com/xy-planning-network/trails/http/template/templatetest"
 	"github.com/xy-planning-network/trails/logger"
 	"github.com/xy-planning-network/trails/ranger"
-	"golang.org/x/exp/slog"
 )
 
 func TestMaintModeHandler(t *testing.T) {


### PR DESCRIPTION
Go 1.21

Notably, replaces `golang.org/x/exp/slog` for `log/slog`

A later PR would introduce any changes the new [`maps`](https://pkg.go.dev/maps) and [`slices`](https://pkg.go.dev/slices) std lib pkgs enable.