### PR TITLE
Logger path fix

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -134,16 +134,12 @@ func DeleteMessageAttr(groups []string, a slog.Attr) slog.Attr {
 func TruncSourceAttr(groups []string, a slog.Attr) slog.Attr {
 	if a.Key == slog.SourceKey {
 		var val string
-		switch v := a.Value.Any().(type) {
-		case runtime.Frame: //NOTE(dlk): github.com/xy-planning-network/tint
+		if v, ok := a.Value.Any().(*slog.Source); ok {
 			val = immediateFilepath(v.File)
 			val += ":" + strconv.Itoa(v.Line)
 
-		case string: //NOTE(dlk): golang.org/x/exp/slog
-			val = immediateFilepath(v)
+			a = slog.Attr{Key: slog.SourceKey, Value: slog.StringValue(val)}
 		}
-
-		a = slog.Attr{Key: slog.SourceKey, Value: slog.StringValue(val)}
 	}
 
 	return a


### PR DESCRIPTION
## Problem statement
Using the `exp` pkg for `slog` meant the API would change before landing in the std lib - and it has! As well, the pkg used for colorizing output made the jump from `exp` to std lib. The type switch to overwrite the source file & line number broke, accordingly.

## What this does
This PR replaces the type switch for an assertion given the std lib `slog` and `tint` pkg both coalesced on the same type.