### PR TITLE
Adds DATABASE_MAX_IDLE_CXNS for configuring DB idle connection pooling

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -49,18 +49,20 @@ const (
 	sentryDsnEnvVar = "SENTRY_DSN"
 
 	// Database defaults
-	dbHostEnvVar         = "DATABASE_HOST"
-	defaultDBHost        = "localhost"
-	dbNameEnvVar         = "DATABASE_NAME"
-	dbPassEnvVar         = "DATABASE_PASSWORD"
-	dbPortEnvVar         = "DATABASE_PORT"
-	defaultDBPort        = "5432"
-	dbSSLModeEnvVar      = "DATABASE_SSLMODE"
-	defaultDBSSLMode     = "prefer"
-	dbURLEnvVar          = "DATABASE_URL"
-	dbUserEnvVar         = "DATABASE_USER"
-	dbMaxIdleCxnsEnvVar  = "DATABASE_MAX_IDLE_CXNS"
-	defaultDBMaxIdleCxns = 1
+	dbHostEnvVar        = "DATABASE_HOST"
+	defaultDBHost       = "localhost"
+	dbNameEnvVar        = "DATABASE_NAME"
+	dbPassEnvVar        = "DATABASE_PASSWORD"
+	dbPortEnvVar        = "DATABASE_PORT"
+	defaultDBPort       = "5432"
+	dbSSLModeEnvVar     = "DATABASE_SSLMODE"
+	defaultDBSSLMode    = "prefer"
+	dbURLEnvVar         = "DATABASE_URL"
+	dbUserEnvVar        = "DATABASE_USER"
+	dbMaxIdleCxnsEnvVar = "DATABASE_MAX_IDLE_CXNS"
+	// NOTE(dlk): same as database/sql
+	// cf., https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/database/sql/sql.go;l=912
+	defaultDBMaxIdleCxns = 2
 
 	// Default HTML template files
 	defaultTmplDir               = "tmpl"

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -49,16 +49,18 @@ const (
 	sentryDsnEnvVar = "SENTRY_DSN"
 
 	// Database defaults
-	dbHostEnvVar     = "DATABASE_HOST"
-	defaultDBHost    = "localhost"
-	dbNameEnvVar     = "DATABASE_NAME"
-	dbPassEnvVar     = "DATABASE_PASSWORD"
-	dbPortEnvVar     = "DATABASE_PORT"
-	defaultDBPort    = "5432"
-	dbSSLModeEnvVar  = "DATABASE_SSLMODE"
-	defaultDBSSLMode = "prefer"
-	dbURLEnvVar      = "DATABASE_URL"
-	dbUserEnvVar     = "DATABASE_USER"
+	dbHostEnvVar         = "DATABASE_HOST"
+	defaultDBHost        = "localhost"
+	dbNameEnvVar         = "DATABASE_NAME"
+	dbPassEnvVar         = "DATABASE_PASSWORD"
+	dbPortEnvVar         = "DATABASE_PORT"
+	defaultDBPort        = "5432"
+	dbSSLModeEnvVar      = "DATABASE_SSLMODE"
+	defaultDBSSLMode     = "prefer"
+	dbURLEnvVar          = "DATABASE_URL"
+	dbUserEnvVar         = "DATABASE_USER"
+	dbMaxIdleCxnsEnvVar  = "DATABASE_MAX_IDLE_CXNS"
+	defaultDBMaxIdleCxns = 1
 
 	// Default HTML template files
 	defaultTmplDir               = "tmpl"
@@ -137,6 +139,8 @@ func NewPostgresConfig(env trails.Environment) *postgres.CxnConfig {
 	default:
 		cfg = &postgres.CxnConfig{IsTestDB: false, URL: url}
 	}
+
+	cfg.MaxIdleCxns = trails.EnvVarOrInt(dbMaxIdleCxnsEnvVar, defaultDBMaxIdleCxns)
 
 	return cfg
 }


### PR DESCRIPTION
## Problem statement
My research for the performance regression for [this Notion ticket](https://www.notion.so/xylabs/Address-ReconciliationProcedures-Diff-performance-regression-7bfb0299d89249a0b163b10276c30900?pvs=4) led to an interesting finding. The simplest, easiest "win" was to not close/discard idle DB connections. The handler returned 33% faster on average.

Currently, a query opens a database connection and closes it when it completes. There is no default connection pooling enabled.

## What this does
This PR adds an env var `DATABASE_MAX_IDLE_CXNS` which allows for keeping open a certain number of idle database connections. The number of actual connections can exceed the max, but when queries complete, the connection returns to the pool until the pool equals `DATABASE_MAX_IDLE_CXNS`. If the max has been reached, it closes the connection.

Without setting the env var, the default is `2` - the same default in `database/sql`.

NB: unless I'm mistaken, this kind of setting is not a PostgreSQL thing (which does have a concept of max connections, fwiw), and comes from `database/sql`. It is a feature of the connection pooling the std lib pkg provides.

I had a hard time finding where the `database/sql` default was overriden, but my guess is [`pgx`](https://github.com/jackc/pgx) since it does not use its pooling library by default.

## Discussion
The proc that was helped by this change runs a lot of small queries because of work performed across goroutines. Goroutines were the original performance solution The re-opening of those connections appears to have a demonstrable impact on the procs performance overall.

Refactoring the proc itself is an always an option so that it performs less queries. Those would be more complicated queries, so it appears simpler to me to not have this internal bottleneck.

I expect this change to have a blast radius larger than the one proc I was focused on (given this is run locally, I struggled to find another endpoint I could hit that was slow enough to also test against). I speculate this will have a positive impact on overall HTTP response times (e.g., `/benefits` is likely slow because of the number of SQL queries being performed, rather than there being 1 meaningfully slow query). Of course, the opposite could happen, so I'd like to set up a test to validate this hypothesis - something to discuss?