### PR TITLE
Add ID for sessions 

### DIFF
--- a/http/session/session.go
+++ b/http/session/session.go
@@ -60,7 +60,7 @@ func (s Session) Flashes(w http.ResponseWriter, r *http.Request) []Flash {
 }
 
 // Get retrieves a value from the session according to the key passed in.
-func (s Session) Get(key string) any {
+func (s Session) Get(key any) any {
 	return s.s.Values[key]
 }
 

--- a/http/session/store.go
+++ b/http/session/store.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/boj/redistore"
+	"github.com/google/uuid"
 	gorilla "github.com/gorilla/sessions"
 	"github.com/xy-planning-network/trails"
 )
@@ -115,6 +116,10 @@ func NewStoreService(cfg Config, opts ...ServiceOpt) (Service, error) {
 // or creates a brand new one.
 func (s Service) GetSession(r *http.Request) (Session, error) {
 	session, err := s.store.Get(r, s.sn)
+	if _, ok := session.Values[trails.SessionIDKey]; !ok {
+		session.Values[trails.SessionIDKey] = uuid.NewString()
+	}
+
 	return Session{s: session}, err
 }
 

--- a/keys.go
+++ b/keys.go
@@ -17,6 +17,9 @@ const (
 
 	// SessionKey stashes the session associated with an HTTP request.
 	SessionKey Key = "SessionKey"
+
+	// SessionIDKey stashes a unique UUID for each session.
+	SessionIDKey Key = "SessionIDKey"
 )
 
 // String formats the stringified key with additional contextual information


### PR DESCRIPTION
## Problem statement
Two problems:
1. only authenticated sessions persist between requests; each unauthenticated request starts a new session
  - This is because `session.Session.Save` is not called for every session created, and instead was saved only when other methods like adding flashes or registering a user.

2. there's no unique identifier to track sessions across requests

## What this does
This PR adds a UUID to each session. And, it saves sessions for all requests during the `InjectSession` middleware.