### PR TITLE
ranger/ranger: logs commit hash in Guide

### DIFF
--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -161,6 +162,15 @@ func (r *Ranger) Guide() error {
 	}()
 
 	go func() {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					r.Info("running on commit: "+setting.Value, &logger.LogContext{Caller: pc})
+					break
+				}
+			}
+		}
+
 		r.Info(fmt.Sprintf("running web server at %s", r.srv.Addr), &logger.LogContext{Caller: pc})
 		r.srv.Handler = r.Router
 		if err := r.srv.ListenAndServe(); err != http.ErrServerClosed {


### PR DESCRIPTION
## Problem statement
We've had trouble debugging failed deployments to AWS and their subsequent rollbacks. As well, there's no single, clear way to identify which build was deployed, especially if there are cascading rollbacks.

## What this does
This PR utilizes `runtime/debug` to pull in the git commit hash and emit a log message with that info.

To leverage it include `-buildvcs=true` in your `go build` or `go run` statements _and_ point to the package, not `main.go`. For example, here's my alias on my machine:
```
go run -buildvcs=true ./cmd/web
```

Then, see how the `Makefile` for a project changes [here](https://github.com/xy-planning-network/college-try/commit/c1e7032ff50f70ef6452f37b900f7b3603a7eee0).

NB: `go help build`
```
        -buildvcs
                Whether to stamp binaries with version control information
                ("true", "false", or "auto"). By default ("auto"), version control
                information is stamped into a binary if the main package, the main module
                containing it, and the current directory are all in the same repository.
                Use -buildvcs=false to always omit version control information, or
                -buildvcs=true to error out if version control information is available but
                cannot be included due to a missing tool or ambiguous directory structure.
```