### PR TITLE
Logs all requests to assets, client, and not found

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -305,9 +305,10 @@ func defaultRouter(
 	env trails.Environment,
 	baseURL *url.URL,
 	responder *resp.Responder,
+	logReqMiddleware middleware.Adapter,
 	mws []middleware.Adapter,
 ) router.Router {
-	route := router.NewRouter(env.String())
+	route := router.New(env.String(), logReqMiddleware)
 	route.OnEveryRequest(mws...)
 	route.HandleNotFound(http.HandlerFunc(func(wx http.ResponseWriter, rx *http.Request) {
 		if strings.Contains(rx.Header.Get("Accept"), "text/html") && rx.URL.Path != baseURL.Path {


### PR DESCRIPTION
## Problem statement
Requests for assets, distributed client, and not found paths are not logged currently. This hinders observability and debugging.

## What this does
This PR includes the `middleware.LogRequest` middleware on the handlers for requests to filesystem resources - i.e., the built client and assets. There's a bit of refactoring in here to help with readability.

As well, requests ending up in `404` or `307` because of not found are logged.