### PR TITLE
http/router: refactor

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -307,10 +307,10 @@ func defaultRouter(
 	responder *resp.Responder,
 	logReqMiddleware middleware.Adapter,
 	mws []middleware.Adapter,
-) router.Router {
-	route := router.New(env.String(), logReqMiddleware)
-	route.OnEveryRequest(mws...)
-	route.HandleNotFound(http.HandlerFunc(func(wx http.ResponseWriter, rx *http.Request) {
+) *router.Router {
+	r := router.New(env.String(), logReqMiddleware)
+	r.OnEveryRequest(mws...)
+	r.HandleNotFound(http.HandlerFunc(func(wx http.ResponseWriter, rx *http.Request) {
 		if strings.Contains(rx.Header.Get("Accept"), "text/html") && rx.URL.Path != baseURL.Path {
 			responder.Redirect(wx, rx, resp.ToRoot())
 			return
@@ -319,7 +319,7 @@ func defaultRouter(
 		wx.WriteHeader(http.StatusNotFound)
 	}))
 
-	return route
+	return r
 }
 
 // defaultSessionStore constructs a SessionStorer to be used for storing session data.

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -36,7 +36,7 @@ type RangerUser interface {
 type Ranger struct {
 	logger.Logger
 	*resp.Responder
-	router.Router
+	*router.Router
 
 	cancel    context.CancelFunc
 	ctx       context.Context


### PR DESCRIPTION
- Removes `Router` interface; renames `DefaultRouter` to `Router`: reason, YAGNI
- Improves code readability by unnesting functions in favor of assigning to an identifier