### PR TITLE
exports postgres.MigrateUp, call in *ranger.Ranger.Guide

### DIFF
--- a/postgres/migrate.go
+++ b/postgres/migrate.go
@@ -35,7 +35,7 @@ func (m Migration) execute(db *gorm.DB) error {
 	return nil
 }
 
-func migrateUp(db *gorm.DB, migrations []Migration) error {
+func MigrateUp(db *gorm.DB, migrations []Migration) error {
 	// Ensure public schema exists
 	ensurePublicSchema(db)
 

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -30,8 +30,10 @@ type CxnConfig struct {
 	MaxIdleCxns int
 }
 
-// Connect creates a database connection through GORM according to the connection config and runs all migrations.
-func Connect(config *CxnConfig, migrations []Migration, env trails.Environment) (*gorm.DB, error) {
+// Connect creates a database connection through GORM according to the connection config.
+//
+// Run migrations by passing DB into MigrateUp.
+func Connect(config *CxnConfig, env trails.Environment) (*gorm.DB, error) {
 	// https://gorm.io/docs/logger.html
 	c := logger.Config{
 		SlowThreshold:             200 * time.Millisecond,
@@ -68,10 +70,6 @@ func Connect(config *CxnConfig, migrations []Migration, env trails.Environment) 
 		if err := gormDB.Exec("DROP SCHEMA IF EXISTS public CASCADE;").Error; err != nil {
 			return nil, err
 		}
-	}
-
-	if err := migrateUp(gormDB, migrations); err != nil {
-		return nil, err
 	}
 
 	return gormDB, nil

--- a/ranger/config.go
+++ b/ranger/config.go
@@ -81,8 +81,3 @@ func (Config[U]) defaultUserStore(db postgres.DatabaseService) middleware.UserSt
 		return user, nil
 	}
 }
-
-type WorkerConfig struct {
-	// Migrations are a list of DB migrations to run upon DB successful connection.
-	Migrations []postgres.Migration
-}

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -152,8 +152,8 @@ func NewPostgresConfig(env trails.Environment) *postgres.CxnConfig {
 // defaultDB connects to a Postgres database
 // using default configuration environment variables
 // and runs the list of [postgres.Migration] passed in.
-func defaultDB(env trails.Environment, list []postgres.Migration) (postgres.DatabaseService, error) {
-	db, err := postgres.Connect(NewPostgresConfig(env), list, env)
+func defaultDB(env trails.Environment) (postgres.DatabaseService, error) {
+	db, err := postgres.Connect(NewPostgresConfig(env), env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem statement
Migrations run prematurely in app startup. In all use cases, app initialization means constructing a `*ranger.Ranger` before emitting properties from it for other app services, procedures, etc. Because migrations run when establishing the database connection, this is too early in an app's startup. Migrations should be the last operation before starting an app due to the unknowns reversing their schema and data changes.

As well, there are no longer any uses for running migrations when building a worker, so this change of use case needs to be updated in `ranger`.

[Notion ticket](https://www.notion.so/xylabs/Spike-DB-migrations-f73c55740a1546459f6d28d40a162da4?pvs=4)

## What this does
This PR exports `postgres.MigrateUp` so a `*ranger.Range` can call it in `Guide`. `Guide` is the final step in app startup since it begins accepting HTTP requests, so provides the best opportunity for delaying running migrations.

This PR removes `ranger.WorkerConfig` given the use for running migrations is no longer necessary.