### PR TITLE
ranger/ranger: logs GoVersion in Guide

### DIFF
--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -181,7 +181,7 @@ func (r *Ranger) Guide() error {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {
 				if setting.Key == "vcs.revision" {
-					r.Info("running on commit: "+setting.Value, &logger.LogContext{Caller: pc})
+					r.Info(fmt.Sprintf("running %s on commit: %s", info.GoVersion, setting.Value), &logger.LogContext{Caller: pc})
 					break
 				}
 			}


### PR DESCRIPTION
I was hoping to be able to check our logs for our currently running Go version to determine our exposure to [CVE-2023-44487](https://github.com/golang/go/issues/63417), and figured this would be a nice add.