### PR TITLE
leave default server host empty

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -356,7 +356,7 @@ func defaultSessionStore(env trails.Environment, appName string) (session.Sessio
 
 // defaultServer constructs a default [*http.Server].
 func defaultServer(ctx context.Context) *http.Server {
-	host := trails.EnvVarOrString(hostEnvVar, DefaultHost)
+	host := trails.EnvVarOrString(hostEnvVar, "")
 	port := trails.EnvVarOrString(portEnvVar, DefaultPort)
 	if port[0] != ':' {
 		port = ":" + port

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -356,7 +356,7 @@ func defaultSessionStore(env trails.Environment, appName string) (session.Sessio
 
 // defaultServer constructs a default [*http.Server].
 func defaultServer(ctx context.Context) *http.Server {
-	host := trails.EnvVarOrString(hostEnvVar, "")
+	host := os.Getenv(hostEnvVar)
 	port := trails.EnvVarOrString(portEnvVar, DefaultPort)
 	if port[0] != ':' {
 		port = ":" + port


### PR DESCRIPTION
# What this does

Follow up to #70 after we discovered [deployment issues with AppRunner](https://www.notion.so/xylabs/8f16954aa3494675837f0cceb6a21c95?v=9d015d84f6fa48fe837c8ad0f6ab5be8&p=94385073857946458fd4bfe060573a41&pm=s)

- leaves the `defaultServer` host empty when `HOST` is not set

## Note:

The goal here is to avoid adding more configuration details to our container based deployments by either requiring another ENV, a change to the Dockerfile, or a change to the AppRunner config.  FWIW, I do expect setting `HOST=0.0.0.0` would also resolve the app runner deployment issue, but Docker networking is difficult to keep top of mind and I just assume stay close to the defaults.  Letting the host stay empty when `HOST` is not set lets local dev setups handle the MacOS firewall warning that initially prompted #70.