### PR TITLE
http/resp: report all errors

### DIFF
--- a/http/middleware/authorize_test.go
+++ b/http/middleware/authorize_test.go
@@ -25,7 +25,7 @@ func TestAuthorizeApplicator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%p", middleware.NoopAdapter), fmt.Sprintf("%p", adpt))
 
 	// Arrange
-	d := resp.NewResponder()
+	d := resp.NewResponder(resp.WithRootUrl("/"))
 
 	app = middleware.NewAuthorizeApplicator[testUser](d)
 	adpt = app.Apply(func(u testUser) (string, bool) {

--- a/http/resp/responder.go
+++ b/http/resp/responder.go
@@ -390,12 +390,8 @@ func (doer *Responder) do(w http.ResponseWriter, r *http.Request, opts ...Fn) (*
 
 	// NOTE(dlk): wrapup errors to send back
 	if len(redos) != 0 {
-		for i, opt := range redos {
-			nested := opt(*doer, resp)
-			if i == 0 {
-				continue
-			}
-			err = fmt.Errorf("%w: %s", nested, err)
+		for _, opt := range redos {
+			err = errors.Join(opt(*doer, resp), err)
 		}
 	}
 

--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -43,7 +43,6 @@ func Authed() Fn {
 		if err := populateUser(d, r); err != nil {
 			return err
 		}
-
 		var n int
 		for _, tmpl := range r.tmpls {
 			if tmpl != d.templates.unauthed {
@@ -53,6 +52,7 @@ func Authed() Fn {
 		}
 
 		r.tmpls = append([]string{d.templates.authed, d.templates.additionalScripts}, r.tmpls[:n]...)
+
 		return nil
 	}
 }
@@ -270,6 +270,17 @@ func Url(u string) Fn {
 		if err != nil {
 			return fmt.Errorf("%w: u is not a valid URL: %v", ErrInvalid, err)
 		}
+
+		if r.url != nil {
+			q := parsed.Query()
+			for k, vv := range r.url.Query() {
+				for _, v := range vv {
+					q.Add(k, v)
+				}
+			}
+			parsed.RawQuery = q.Encode()
+		}
+
 		r.url = parsed
 		return nil
 	}


### PR DESCRIPTION
## Problem statement
When doing `*Responder.Html(w, r, Authed(), Vue("MyPage"))` - a common pattern in our web handlers - and there is no `currentUser`, no error raises when it should.

A separate bug surfaced here where calling `Url` and `Params` overwrote the query params set. The order shouldn't matter.

## What this does
This uses `errors.Join` to merge all errors together when looping through the functional options passed to a `Responder` method.

Also, `Url` merges with query params set before it was called.