### PR TITLE
[ PROPOSAL ] Generic DB calls

### DIFF
--- a/postgres/service.go
+++ b/postgres/service.go
@@ -1,27 +1,151 @@
 package postgres
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
 	"math"
 
+	"github.com/xy-planning-network/trails"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-// DatabaseService sets up the interface to be used at the handler/middelware level. These should be straightforward
-// calls that allow us to skip creating a procedure method for the most basic database interactions. At the procedural
-// layer, the *gorm.DB struct is available directly for more complex composition. This has the intended functionality
-// that we are not testing the database in handlers, while it is tested directly at the procedural layer.
-type DatabaseService interface {
-	CountByQuery(model any, query map[string]any) (int64, error)
-	FetchByQuery(models any, query string, params []any) error
-	FindByID(model any, ID any) error
-	FindByQuery(model any, query map[string]any) error
-	PagedByQuery(models any, query string, params []any, order string, page int, perPage int, preloads ...string) (PagedData, error)
-	PagedByQueryFromSession(models any, session *gorm.DB, page int, perPage int) (PagedData, error)
+type Simple[T any] struct {
+	db *gorm.DB
 }
 
-// PagedData is returned from the PagedByQuery method. It contains paged database records and pagination metadata.
-type PagedData struct {
-	Items      any   `json:"items"`
+func NewSimple[T any](db *gorm.DB) *Simple[T] {
+	return &Simple[T]{db}
+}
+
+func (db *Simple[T]) Debug() *Simple[T] { return db }
+
+func (db *Simple[T]) Distinct(args ...interface{}) *Simple[T] { return db }
+
+func (db *Simple[T]) Find() (T, error) { return nil }
+
+func (db *Simple[T]) First() (T, error) {
+	var dest T
+	err := db.db.Model(&dest).First(&dest).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("%w", trails.ErrNotFound)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%w: %s", trails.ErrUnexpected, err)
+	}
+
+	return nil
+}
+
+func (db *Simple[T]) Group(name string) *Simple[T] { return db }
+
+func (db *Simple[T]) Joins(query string, args ...interface{}) *Simple[T] { return db }
+
+func (db *Simple[T]) Limit(limit int) *Simple[T] { return db }
+
+func (db *Simple[T]) Offset(offset int) *Simple[T] { return db }
+
+func (db *Simple[T]) Or(query interface{}, args ...interface{}) *Simple[T] { return db }
+
+func (db *Simple[T]) Order(value interface{}) *Simple[T] { return db }
+
+func (db *Simple[T]) Paged(page, perPage int) (PagedData[T], error) {
+	var pd PagedData[T]
+	var items T
+
+	// Make sure page/perPage are sane
+	page = max(1, page)
+	perPage = max(1, perPage)
+
+	// Conduct unlimited count query to calculate totals
+	var totalRecords int64
+	if err := db.db.Model(&items).Session(new(gorm.Session)).Count(&totalRecords).Error; err != nil {
+		err = fmt.Errorf("%w: %s", trails.ErrUnexpected, err)
+		return pd, err
+	}
+
+	// Calculate offset and conduct limited query
+	offset := (page - 1) * perPage
+	if err := db.db.Model(&items).Limit(perPage).Offset(offset).Find(&items).Error; err != nil {
+		err = fmt.Errorf("%w: %s", trails.ErrUnexpected, err)
+		return pd, err
+	}
+
+	pd.Items = items
+	pd.Page = page
+	pd.PerPage = perPage
+	pd.TotalItems = totalRecords
+	totalPagesFloat := float64(totalRecords) / float64(perPage)
+	pd.TotalPages = int(math.Ceil(totalPagesFloat))
+
+	return pd, nil
+}
+
+func (db *Simple[T]) Preload(query string, args ...interface{}) *Simple[T] { return db }
+
+func (db *Simple[T]) Scopes(funcs ...func(*Simple[T]) *Simple[T]) *Simple[T] { return db }
+
+func (db *Simple[T]) Select(columns ...string) *Simple[T] { return db }
+
+// Table specifies the name of the table to query when T is not a struct matching a database table.
+//
+// e.g.:
+//
+//	ids, err := NewSimple[[]uint].Table("users").Select("id").Find()
+func (db *Simple[T]) Table(name string) *Simple[T] {}
+
+func (db *Simple[T]) Unscoped() *Simple[T] { return db }
+
+func (db *Simple[T]) Where(query interface{}, args ...interface{}) *Simple[T] {
+	return &Simple[T]{db.db.Where(query, args...)}
+}
+
+type Robust[T any] struct {
+	*Simple[T]
+}
+
+func (db *Robust[T]) Begin(opts ...*sql.TxOptions) *Robust[T] { return db }
+
+func (db *Robust[T]) Commit() error { return nil }
+
+func (db *Robust[T]) Create(value T) error { return nil }
+
+// escape hatch
+func (db *Robust[T]) DB() *gorm.DB { return db.db }
+
+func (db *Robust[T]) Delete(value T) error { return nil }
+
+func (db *Robust[T]) Exec(sql string, values ...interface{}) (int64, error) {
+	var err error
+	res := db.db.Exec(sql, values...)
+	if res.Error != nil {
+		err = fmt.Errorf("%w: %s", trails.ErrUnexpected, err)
+	}
+	return res.RowsAffected, err
+}
+
+func (db *Robust[T]) Raw(dest interface{}, sql string, values ...interface{}) error { return nil }
+
+func (db *Robust[T]) Rollback() *Robust[T] { return db }
+
+func (db *Robust[T]) Update(column string, value interface{}) (T, error) { return db }
+
+func (db *Robust[T]) Updates(values interface{}) (T, error) {
+	var dest T
+	err := db.db.Model(&dest).Clauses(clause.Returning{} /* GORM's RETURNING * syntax */).Updates(values).Error
+	if err != nil {
+		err = fmt.Errorf("%w: %s", trails.ErrUnexpected, err)
+		return dest, err
+	}
+
+	return dest, nil
+}
+
+// PagedData is returned from the Paged method. It contains paged database records and pagination metadata.
+type PagedData[T any] struct {
+	Items      T     `json:"items"`
 	Page       int   `json:"page"`
 	PerPage    int   `json:"perPage"`
 	TotalItems int64 `json:"totalItems"`


### PR DESCRIPTION
## Proposal

This PR rewrites the `DatabaseService` interface by providing two wrappers around a `*gorm.DB`: `Simple[T]` and `Robust[T]`. In both cases, `T` identifies the return value of terminal methods like `First`, `Find`, `Update` and so on. `Simple[T]` will be made available to HTTP handlers, which generally do not (i.e., ought not) mutate data and simply only read it. `Robust[T]` will be made available to procs so they can read, write, update and delete.

### Problem statement
There are two goals:
1. leverage generics to simplify initializing values returned from queries; and,
2. restrict the flexibility of GORM's API so we more closely approach "one way" to access the database.

#### flexibility
Let's start with (2). We care about restricting the flexibility of GORM's API for two main reasons. First, it curtails using some facets of the type loose-ness of the GORM API. Second, it closes off the need to enforce patterns in PR review. Right now, we use our shared experience and that's becoming a pain point as more of us work in `college-try`. Currently, our handlers use `DatabaseService` while procs use `*gorm.DB`. Let's talk about the issues there.

`DatabaseService` is a solution to (2) by limiting what kinds of queries can happen and what can be expressed by those queries. I find the solution to be too divorced from both SQL syntax and GORM's API that I generally always copy/paste from an example in order to ensure I'm using a function signature correctly. It doesn't seem necessary, in any case, to have another _way_ of expressing a query, as the functions, and instead can solve the problem another way.

On the procs side, there is no existing solution to the flexibility of GORM's API and you will find between `college-try` and `second-child` meaningfully different ways of querying. That can entail the strings passed into many of GORM's methods or even which methods are called (e.g., `Pluck` vs. `Select`).

The goal, then, is to replace _both_ of these with `Simple[T]` subbing in for `DatabaseService` and `Robust[T]` subbing in for `*gorm.DB`.

#### generics
(1) is a new goal and is a QoL improvement made possible

### What this does
This PR is an outline of `Simple[T]` and `Robust[T]`. In a few methods, I've scratched out how those methods are implemented so the idea is clearer.

`First`, `Find`, `Count`, `Paged`, `Update`, `Updates`, `Create`, `Delete`, `Exec`, `Raw` finish a query. When called, they return a `T` with the results of the previously built query. If they fail, they gracefully wrap errors in a `trails` defined error.

`First` returns a single item; `Find` returns a list. For both methods, `T` would be just the single type rather than a slice of `T`. That is:
```go
user, err := NewSimple[domain.User]Where("id = ?", id).First()

users, err := NewSimple[domain.User].Where("access_state = ?", domain.AccessGranted).Find()
``` 

Other methods build a query. These leverage the same builder pattern in GORM. Generally speaking, these query building methods will simply call the GORM equivalent. Only where we want to add in some functionality would they diverge from GORM.

#### TODOs
- [ ] The specifics of `Begin` and `Commit` given terminal methods don't return a `Robust[T]`.
- [ ] Confirm how to implement the builder pattern.
- [ ] Confirm whether `Model` and `Table` conflict