### PR TITLE
Changes from Compare to Contains to catch when application/json is ne…

### DIFF
--- a/http/middleware/current_user.go
+++ b/http/middleware/current_user.go
@@ -164,7 +164,7 @@ func RequireAuthed(loginUrl, logoffUrl string) Adapter {
 func handleErr(w http.ResponseWriter, r *http.Request, code int, d *resp.Responder, err error) {
 	vs := r.Header.Values("Accept")
 	for _, v := range vs {
-		if strings.Compare(v, "application/json") == 0 {
+		if strings.Contains(v, "application/json") {
 			d.Json(w, r, resp.Err(err), resp.Code(code))
 			return
 		}

--- a/http/middleware/current_user_test.go
+++ b/http/middleware/current_user_test.go
@@ -106,6 +106,25 @@ func TestCurrentUser(t *testing.T) {
 	require.Nil(t, err)
 
 	r = r.Clone(context.WithValue(r.Context(), trails.SessionKey, s))
+	r.Header.Set("Accept", "application/json, text/plain, */*")
+
+	// Act
+	middleware.CurrentUser(
+		resp.NewResponder(resp.WithRootUrl("https://example.com")),
+		newFailedUserStore(true),
+	)(teapotHandler()).ServeHTTP(w, r)
+
+	// Assert
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Arrange
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+
+	s, err = session.NewStub(true).GetSession(r)
+	require.Nil(t, err)
+
+	r = r.Clone(context.WithValue(r.Context(), trails.SessionKey, s))
 	r.Header.Set("Accept", "application/json")
 
 	// Act


### PR DESCRIPTION
…sted in string

Found 307 in logs for api call after sentry error:

https://xy-planning-network.sentry.io/issues/5007098413/?project=1813622

Accept is coming through as a single comma separated value like `application/json, text/plain, */*` instead of `[]string{"application/json", "text/plain", "*/*"}`.