### PR TITLE
ranger: enables logging HTTP req validation errors

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -43,11 +43,13 @@ const (
 	environmentEnvVar = "ENVIRONMENT"
 
 	// Log defaults
-	logLevelEnvVar  = "LOG_LEVEL"
-	defaultLogLvl   = slog.LevelInfo
-	logJSONEnvVar   = "LOG_JSON"
-	defaultLogJSON  = false
-	sentryDsnEnvVar = "SENTRY_DSN"
+	logLevelEnvVar             = "LOG_LEVEL"
+	defaultLogLvl              = slog.LevelInfo
+	logJSONEnvVar              = "LOG_JSON"
+	defaultLogJSON             = false
+	sentryDsnEnvVar            = "SENTRY_DSN"
+	logValidationErrorsEnvVar  = "LOG_VALIDATION"
+	defaultLogValidationErrors = false
 
 	// Database defaults
 	dbHostEnvVar        = "DATABASE_HOST"


### PR DESCRIPTION
Based on @profsmallpine's feedback, I gathered there's a need for logging validation errors as another datapoint available when debugging why a client payload wasn't accepted. This PR adds the `LOG_VALIDATION` env var that when set to `true` logs errors originating from HTTP request validation functionality (they'd also go to Sentry if that's enabled).