### PR TITLE
adds SESSION_DOMAIN for specifying the domain to set on session cookies

### DIFF
--- a/http/session/store.go
+++ b/http/session/store.go
@@ -38,8 +38,11 @@ type Service struct {
 	store gorilla.Store
 }
 
-// A Config provides the required values
+// A Config provides values required for constructing a session.Service.
 type Config struct {
+	// The domain to assign cookies to.
+	Domain string
+
 	Env trails.Environment
 
 	// The number of seconds a session is valid.
@@ -97,6 +100,7 @@ func NewStoreService(cfg Config) (Service, error) {
 		c = gorilla.NewCookieStore(s.ak)
 	}
 
+	c.Options.Domain = cfg.Domain
 	c.Options.Secure = !(s.env.IsDevelopment() || s.env.IsTesting())
 	c.Options.HttpOnly = true
 	c.MaxAge(cfg.MaxAge)

--- a/ranger/doc.go
+++ b/ranger/doc.go
@@ -1,5 +1,4 @@
 /*
-
 Package ranger initializes and manages a trails app with sane defaults.
 
 # Ranger
@@ -31,6 +30,7 @@ found at the same directory the application is executed from.
 Here are the available environment variables.
   - APP_DESCRIPTION: a short description of the application
   - APP_TITLE: a short title for the application
+  - ASSETS_URL: the base URL the application serves client-side assets over
   - BASE_URL: the base URL the application runs on; replaces HOST & PORT
   - CONTACT_US: the email address end users can contact XYPN at; default: hello@xyplanningnetwork.com
   - DATABASE_HOST: the host the database is running on; default: localhost
@@ -48,5 +48,6 @@ Here are the available environment variables.
   - SERVER_WRITE_TIMEOUT: the timeout - as understood by [time.ParseDuration] - for writing HTTP responses; default: 5s
   - SESSION_AUTH_KEY: a hex-encoded key for authenticating cookies; cf. [encoding/hex]
   - SESSION_ENCRYPTION_KEY: a hex-encoded key for encrypting cookies; cf. [encoding/hex]
+  - SESSION_DOMAIN: the host the application is served over for setting as the cookie's domain; default: the hostname of BASE_URL
 */
 package ranger

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -99,7 +99,7 @@ func New[U RangerUser](cfg Config[U]) (*Ranger, error) {
 
 	r.Responder = defaultResponder(r.Logger, r.url, defaultParser(r.env, r.url, r.assetsURL, cfg.FS, r.metadata), r.metadata.Contact)
 
-	r.sessions, err = defaultSessionStore(r.env, r.metadata.Title)
+	r.sessions, err = defaultSessionStore(r.env, r.metadata.Title, r.url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In order for Portal's cookie to be sent in requests to `connect.xyplanningnetwork.com`, we need to set the cookie for our root `xyplanningnetwork.com` domain. Thataways, event handlers for Find an Advisor features can be aware of `currentUser` (cf. [Notion ticket](https://www.notion.so/xylabs/Enable-currentUser-check-on-for-Find-an-Advisor-events-1bcce20905a5476f978d7389c5b12415?pvs=4)).

This PR adds `SESSION_DOMAIN` for enabling this configuration.