### PR TITLE
add cursor to template calls

### DIFF
--- a/ranger/tmpl/layout/authenticated_base.tmpl
+++ b/ranger/tmpl/layout/authenticated_base.tmpl
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Work+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet" />
 
-    {{ template "additionalHeadScripts" }}
+    {{ template "additionalHeadScripts" . }}
 
     {{ if not isDevelopment }}
     <link rel="stylesheet" href="{{ asset "assets/style.css" }}">
@@ -21,7 +21,7 @@
   </head>
 
   <body class="bg-gray-50">
-    {{ template "additionalBodyScripts" }}
+    {{ template "additionalBodyScripts" . }}
 
     {{ template "pageContent" . }}
 

--- a/ranger/tmpl/layout/unauthenticated_base.tmpl
+++ b/ranger/tmpl/layout/unauthenticated_base.tmpl
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Work+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet" />
 
-    {{ template "additionalHeadScripts" }}
+    {{ template "additionalHeadScripts" . }}
 
     {{ if not isDevelopment }}
     <link rel="stylesheet" href="{{ asset "assets/style.css" }}">
@@ -21,7 +21,7 @@
   </head>
 
   <body class="bg-gray-50">
-    {{ template "additionalBodyScripts" }}
+    {{ template "additionalBodyScripts" . }}
 
     {{ template "pageContent" . }}
 


### PR DESCRIPTION
I ran into this when attempting to read `.Data` in the `additional_scripts.tmp` template.  As far as I can tell, these are the only template calls that weren't passing data along.