### PR TITLE
logger: only prints *http.Request.Body or Form if in dev

### DIFF
--- a/http/resp/responder_opt_test.go
+++ b/http/resp/responder_opt_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails"
 	"github.com/xy-planning-network/trails/http/session"
 	"github.com/xy-planning-network/trails/logger"
 )
@@ -33,7 +34,7 @@ func TestResponderWithErrTemplate(t *testing.T) {
 func TestResponderWithLogger(t *testing.T) {
 	// Arrange
 	b := new(bytes.Buffer)
-	l := logger.New(slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{AddSource: true})))
+	l := logger.New(slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{AddSource: true})), trails.Testing)
 	d := NewResponder(WithLogger(l))
 
 	msg := "unit testing is fun!"

--- a/http/resp/responder_test.go
+++ b/http/resp/responder_test.go
@@ -344,7 +344,7 @@ func TestResponderRedirect(t *testing.T) {
 
 func TestResponderHtml(t *testing.T) {
 	b := new(bytes.Buffer)
-	testlog := logger.New(slog.New(slog.NewTextHandler(b, nil)))
+	testlog := logger.New(slog.New(slog.NewTextHandler(b, nil)), trails.Testing)
 
 	brokenTmpl := []byte("{{ define }}")
 	tcs := []struct {

--- a/logger/context.go
+++ b/logger/context.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 
 	"github.com/xy-planning-network/trails"
 )
@@ -157,11 +156,4 @@ func processLogValues(m map[string]any) []slog.Attr {
 		}
 	}
 	return g
-}
-
-// mask replaces all instances of key in q with trails.LogMaskVal.
-func mask(q url.Values, key string) {
-	if val := q.Get(key); val != "" {
-		q.Set(key, trails.LogMaskVal)
-	}
 }

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -89,11 +89,6 @@ func TestLogContextMarshalText(t *testing.T) {
 				"Host":         []any{"example.com"},
 				"Content-Type": []any{"application/x-www-form-urlencoded"},
 			},
-			"form": map[string]any{
-				"email": []any{"husserl@example.com"},
-				"name":  []any{"Edmund Husserl"},
-				"some":  []any{"param"},
-			},
 		},
 	}
 
@@ -131,10 +126,6 @@ func TestLogContextMarshalText(t *testing.T) {
 			"header": map[string]any{
 				"Host":         []any{"example.com"},
 				"Content-Type": []any{"application/json"},
-			},
-			"json": map[string]any{
-				"email": "husserl@example.com",
-				"name":  "Edmund Husserl",
 			},
 		},
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/xy-planning-network/trails"
 )
 
 const (
@@ -54,12 +56,13 @@ type Logger interface {
 
 // TrailsLogger implements [Logger] using [log/slog.Logger].
 type TrailsLogger struct {
+	env  trails.Environment
 	l    *slog.Logger
 	skip int
 }
 
 // New constructs a Logger using [log/slog.Logger].
-func New(log *slog.Logger) Logger { return &TrailsLogger{l: log} }
+func New(log *slog.Logger, env trails.Environment) Logger { return &TrailsLogger{l: log, env: env} }
 
 func (l *TrailsLogger) AddSkip(i int) Logger {
 	newl := *l
@@ -79,6 +82,8 @@ func (l *TrailsLogger) log(level slog.Level, msg string, ctx *LogContext) {
 	if ctx == nil {
 		ctx = new(LogContext)
 	}
+
+	ctx.env = l.env
 
 	pc := ctx.Caller
 	if pc == 0 {

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -167,7 +167,7 @@ func defaultDB(env trails.Environment) (postgres.DatabaseService, error) {
 // defaultAppLogger constructs a [tlog.Logger] configured for use in the application.
 func defaultAppLogger(env trails.Environment, output io.Writer) logger.Logger {
 	slogger := newSlogger(trails.AppLogKind, env, output)
-	l := logger.New(slogger)
+	l := logger.New(slogger, env)
 	l.Debug("setting up app logger", nil)
 	if dsn := os.Getenv(sentryDsnEnvVar); dsn != "" {
 		l = logger.NewSentryLogger(env, l, dsn)
@@ -190,7 +190,7 @@ func defaultHTTPLogger(env trails.Environment, output io.Writer) *slog.Logger {
 // defaultWorkerLogger constructs a [*log/slog.Logger] for use in Faktory worker logging.
 func defaultWorkerLogger(env trails.Environment) logger.Logger {
 	slogger := newSlogger(trails.WorkerLogKind, env, os.Stdout)
-	l := logger.New(slogger)
+	l := logger.New(slogger, env)
 	l.Debug("setting up worker logger", nil)
 	if dsn := os.Getenv(sentryDsnEnvVar); dsn != "" {
 		l = logger.NewSentryLogger(env, l, dsn)

--- a/ranger/ranger_test.go
+++ b/ranger/ranger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xy-planning-network/trails"
 	"github.com/xy-planning-network/trails/http/template"
 	tt "github.com/xy-planning-network/trails/http/template/templatetest"
 	"github.com/xy-planning-network/trails/logger"
@@ -18,7 +19,7 @@ import (
 func TestMaintModeHandler(t *testing.T) {
 	// Arrange
 	b := new(bytes.Buffer)
-	l := logger.New(slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{AddSource: true})))
+	l := logger.New(slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{AddSource: true})), trails.Testing)
 	p := template.NewParser([]fs.FS{tt.NewMockFS(tt.NewMockFile("", nil))})
 	handler := ranger.MaintModeHandler(p, l, "test@example.com")
 	req, err := http.NewRequest("GET", "/", nil)


### PR DESCRIPTION
This PR makes `logger.Logger` environment aware by adding a new param when constructing its `logger.TrailsLogger` implementation. That `Environment` is factored in `logger.LogContext`. Now, when not in dev, the context's request's body and form do not print.

It is useful once in a blue moon to have the raw `*http.Request.Form` or `*http.Request.Body` in the server's logs (as opposed to watching requests in browser dev tools), so opted to keep this around instead of removing entirely.

Fixes DEV-3053