### PR TITLE
leave session domain empty as default

### DIFF
--- a/ranger/default.go
+++ b/ranger/default.go
@@ -340,16 +340,14 @@ func defaultRouter(
 //   - SESSION_ENCRYPTION_KEY
 //
 // Both KEY env vars be valid hex encoded values; cf. [encoding/hex].
-func defaultSessionStore(env trails.Environment, appName string, appURL *url.URL) (session.SessionStorer, error) {
+func defaultSessionStore(env trails.Environment, appName string) (session.SessionStorer, error) {
 	appName = cases.Lower(language.English).String(appName)
 	appName = regexp.MustCompile(`[,':]`).ReplaceAllString(appName, "")
 	appName = regexp.MustCompile(`\s`).ReplaceAllString(appName, "-")
 
-	domain := appURL.Hostname()
-
 	cfg := session.Config{
 		AuthKey:     os.Getenv(SessionAuthKeyEnvVar),
-		Domain:      trails.EnvVarOrString(SessionDomainEnvVar, domain),
+		Domain:      trails.EnvVarOrString(SessionDomainEnvVar, ""),
 		EncryptKey:  os.Getenv(SessionEncryptKeyEnvVar),
 		Env:         env,
 		MaxAge:      int(trails.EnvVarOrDuration(SessionMaxAgeEnvVar, defaultSessionMaxAge).Seconds()),

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -99,7 +99,7 @@ func New[U RangerUser](cfg Config[U]) (*Ranger, error) {
 
 	r.Responder = defaultResponder(r.Logger, r.url, defaultParser(r.env, r.url, r.assetsURL, cfg.FS, r.metadata), r.metadata.Contact)
 
-	r.sessions, err = defaultSessionStore(r.env, r.metadata.Title, r.url)
+	r.sessions, err = defaultSessionStore(r.env, r.metadata.Title)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Leaves the session cookie domain unset as default when `SESSION_DOMAIN` is not set in the environment.