### PR TITLE
allow config for same site mode

### DIFF
--- a/http/session/store.go
+++ b/http/session/store.go
@@ -52,6 +52,9 @@ type Config struct {
 	// Also used as the name of the cookie when WithCookie is used.
 	SessionName string
 
+	// The SameSite mode for the session cookie.
+	SameSiteMode http.SameSite
+
 	// Hex-encoded key
 	AuthKey string
 
@@ -102,7 +105,7 @@ func NewStoreService(cfg Config) (Service, error) {
 
 	c.Options.Domain = cfg.Domain
 	c.Options.HttpOnly = true
-	c.Options.SameSite = http.SameSiteStrictMode
+	c.Options.SameSite = cfg.SameSiteMode
 	c.Options.Secure = !(s.env.IsDevelopment() || s.env.IsTesting())
 	c.MaxAge(cfg.MaxAge)
 

--- a/ranger/default.go
+++ b/ranger/default.go
@@ -92,7 +92,7 @@ const (
 	SessionAuthKeyEnvVar    = "SESSION_AUTH_KEY"
 	SessionEncryptKeyEnvVar = "SESSION_ENCRYPTION_KEY"
 	SessionMaxAgeEnvVar     = "SESSION_MAX_AGE"
-	SessionSameSite         = "SESSION_SAME_SITE"
+	SessionSameSiteMode     = "SESSION_SAMESITE_MODE"
 	defaultSessionMaxAge    = 24 * time.Hour
 
 	// Test defaults
@@ -339,7 +339,7 @@ func defaultRouter(
 //   - SESSION_DOMAIN
 //   - SESSION_AUTH_KEY
 //   - SESSION_ENCRYPTION_KEY
-//   - SESSION_SAME_SITE
+//   - SESSION_SAMESITE_MODE
 //
 // Both KEY env vars be valid hex encoded values; cf. [encoding/hex].
 func defaultSessionStore(env trails.Environment, appName string) (session.SessionStorer, error) {
@@ -348,7 +348,7 @@ func defaultSessionStore(env trails.Environment, appName string) (session.Sessio
 	appName = regexp.MustCompile(`\s`).ReplaceAllString(appName, "-")
 
 	var sameSiteMode http.SameSite
-	switch strings.ToLower(trails.EnvVarOrString(SessionSameSite, "")) {
+	switch strings.ToLower(trails.EnvVarOrString(SessionSameSiteMode, "")) {
 	case "lax":
 		sameSiteMode = http.SameSiteLaxMode
 	case "none":


### PR DESCRIPTION
Allows setting `SESSION_SAMESITE_MODE` to "Strict", "Lax", or "None".  Defaults to "Lax".