### PR TITLE
unexports appPropsKey, exposes interacting with it through AppProps

### DIFF
--- a/http/resp/response.go
+++ b/http/resp/response.go
@@ -393,7 +393,7 @@ func Vue(entry string) Fn {
 		}
 
 		props := map[string]any{"initialProps": init}
-		if val := r.r.Context().Value(trails.AppPropsKey); val != nil {
+		if val := trails.AppPropsFromContext(r.r.Context()); len(val) > 0 {
 			props["appProps"] = val
 		}
 

--- a/http/resp/response_test.go
+++ b/http/resp/response_test.go
@@ -873,7 +873,7 @@ func TestVue(t *testing.T) {
 			// Arrange
 			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 			require.Nil(t, err)
-			tc.r.r = req.Clone(context.WithValue(req.Context(), trails.AppPropsKey, 1))
+			tc.r.r = req.Clone(trails.NewAppPropsContext(req.Context(), map[string]any{"1": 1}))
 
 			// Act
 			err = Vue(tc.entry)(tc.d, tc.r)

--- a/keys.go
+++ b/keys.go
@@ -1,10 +1,12 @@
 package trails
 
+import "context"
+
 type Key string
 
 const (
-	// AppPropsKey stashes additional props to be included in HTTP responses.
-	AppPropsKey Key = "AppPropsKey"
+	// appPropsKey stashes additional props to be included in HTTP responses.
+	appPropsKey Key = "AppPropsKey"
 
 	// CurrentUserKey stashes the currentUser for a session.
 	CurrentUserKey Key = "CurrentUserKey"
@@ -25,4 +27,34 @@ const (
 // String formats the stringified key with additional contextual information
 func (k Key) String() string {
 	return "trails context key: " + string(k)
+}
+
+// An AppProps passes data from the server to the client as a set of props needed for general application state.
+// The data is passed around in a context.Context and rendered as JSON.
+// The data is expected to be marshaled into Vue/JS props.
+//
+// NB: Data not representable by JSON will create errors; review [encoding/json.Marshaler].
+type AppProps map[string]any
+
+// NewAppPropsContext adds props to ctx, returning the resulting context.
+// If props have already been added to ctx, it's key-value pairs are added to existing ones.
+// If any keys collide, those in props overwrite previous values.
+func NewAppPropsContext(ctx context.Context, props AppProps) context.Context {
+	existing := AppPropsFromContext(ctx)
+	for k, v := range props {
+		existing[k] = v
+	}
+
+	return context.WithValue(ctx, appPropsKey, existing)
+}
+
+// AppPropsFromContext retrieves an AppProps in ctx.
+// If not already set, it initializes a new AppProps.
+func AppPropsFromContext(ctx context.Context) AppProps {
+	props, ok := ctx.Value(appPropsKey).(AppProps)
+	if !ok {
+		props = make(AppProps)
+	}
+
+	return props
 }


### PR DESCRIPTION
This PR enables resolving DEV-3094 according to the std lib's approved pattern. [context/Context.Value](https://pkg.go.dev/context#Context.Value) suggests using, what I'm interpreting as, a getter/setter pattern and not exposing the actual const used to store values in a `context.Context`.

The extra guarding, typing, etc. may appear overkill for our uses, but, there's an argument to be made that if we had followed this advice in the first place, we wouldn't have had the unexpected effect we do have of overwriting values in a `context.Context`. So, taking our lumps on this one.

If we're liking this pattern in general, the next step is to move the other keys over to a similar approach. I'd look into the possibility of generics here, but not likely it'll cut down on boilerplate since the core decision to be made with these getters/setters is how to merge together/overwrite an existing value set in a `context.Context` with a new value.

Throwing the actual `map[string]any` into a new type will give us future flexibility, in my opinion, for attaching methods to the type should they become necessary.