### PR TITLE
Fix HTTP Referer header name

### DIFF
--- a/http/middleware/log_request.go
+++ b/http/middleware/log_request.go
@@ -15,7 +15,7 @@ const (
 	passwordParam     = "password"
 	contentLenHeader  = "Content-Length"
 	contentTypeHeader = "Content-Type"
-	referrerHeader    = "Referrer"
+	referrerHeader    = "Referer"
 	userAgentHeader   = "User-Agent"
 )
 

--- a/http/middleware/log_request_test.go
+++ b/http/middleware/log_request_test.go
@@ -111,7 +111,7 @@ func TestLogRequest(t *testing.T) {
 
 			r.Header.Set("User-Agent", useragent)
 			r.Header.Set("Content-Type", content)
-			r.Header.Set("Referrer", referrer)
+			r.Header.Set("Referer", referrer)
 
 			if tc.ip != "" {
 				r = r.Clone(context.WithValue(r.Context(), trails.IpAddrKey, tc.ip))


### PR DESCRIPTION
I was trying to figure out why I wasn't ever seeing any referrer info in our logs, then realized we have better spellcheck than the original author of the spec. (see https://en.wikipedia.org/wiki/HTTP_referer)