### PR TITLE
uint -> int64 #minor

### DIFF
--- a/account.go
+++ b/account.go
@@ -8,7 +8,7 @@ package trails
 type Account struct {
 	Model
 	AccessState    AccessState `json:"accessState"`
-	AccountOwnerID uint        `json:"accountOwnerId"`
+	AccountOwnerID int64       `json:"accountOwnerId"`
 
 	// Associations
 	AccountOwner *User  `json:"accountOwner,omitempty"`

--- a/http/middleware/current_user.go
+++ b/http/middleware/current_user.go
@@ -18,7 +18,7 @@ type User interface {
 }
 
 // UserStorer defines how to retrieve a User by an ID in the context of middleware.
-type UserStorer func(id uint) (User, error)
+type UserStorer func(id int64) (User, error)
 
 // CurrentUser uses storer and the session.Session stored in a *http.Request.Context
 // to check the current user has access

--- a/http/middleware/middleware_test.go
+++ b/http/middleware/middleware_test.go
@@ -24,16 +24,16 @@ type testUser bool
 func (b testUser) HasAccess() bool { return bool(b) }
 func (testUser) HomePath() string  { return "/" }
 func (testUser) GetEmail() string  { return "user@example.com" }
-func (testUser) GetID() uint       { return 1 }
+func (testUser) GetID() int64      { return 1 }
 
 func newTestUserStore(b bool) middleware.UserStorer {
-	return func(_ uint) (middleware.User, error) {
+	return func(_ int64) (middleware.User, error) {
 		return testUser(b), nil
 	}
 }
 
 func newFailedUserStore(b bool) middleware.UserStorer {
-	return func(_ uint) (middleware.User, error) {
+	return func(_ int64) (middleware.User, error) {
 		return testUser(b), errors.New("")
 	}
 }

--- a/http/session/session.go
+++ b/http/session/session.go
@@ -65,7 +65,7 @@ func (s Session) Get(key any) any {
 }
 
 // RegisterUserSession stores the user's ID in the session.
-func (s Session) RegisterUser(w http.ResponseWriter, r *http.Request, ID uint) error {
+func (s Session) RegisterUser(w http.ResponseWriter, r *http.Request, ID int64) error {
 	s.s.Values[trails.CurrentUserKey] = ID
 	return s.Save(w, r)
 }
@@ -95,14 +95,14 @@ func (s Session) SetFlash(w http.ResponseWriter, r *http.Request, flash Flash) e
 // If no user ID can be found, this ErrNoUser is returned.
 // This ought to only happen when a user is going through an authentication workflow or hitting unauthenticated pages.
 //
-// If the value returned from the session is not a uint, ErrNotValid is returned and represents a programming error.
-func (s Session) UserID() (uint, error) {
+// If the value returned from the session is not an int64, ErrNotValid is returned and represents a programming error.
+func (s Session) UserID() (int64, error) {
 	intfVal, ok := s.s.Values[trails.CurrentUserKey]
 	if !ok {
 		return 0, ErrNoUser
 	}
 
-	val, ok := intfVal.(uint)
+	val, ok := intfVal.(int64)
 	if !ok {
 		return 0, ErrNotValid
 	}

--- a/http/session/store.go
+++ b/http/session/store.go
@@ -137,7 +137,7 @@ func NewStub(loggedIn bool) *Stub {
 	s := new(Stub)
 	s.s = gorilla.NewSession(s, "stub")
 	if loggedIn {
-		s.s.Values[trails.CurrentUserKey] = uint(1)
+		s.s.Values[trails.CurrentUserKey] = int64(1)
 	}
 
 	return s

--- a/logger/context.go
+++ b/logger/context.go
@@ -19,7 +19,7 @@ var (
 // LogUser is the interface exposing attributes of a user to a LogContext.
 type LogUser interface {
 	// GetID retrieves the application's identifier for a user.
-	GetID() uint
+	GetID() int64
 
 	// GetEmail retrieves the email address of the user.
 	// If not available, an ID should be returned.

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -150,5 +150,5 @@ func TestLogContextMarshalText(t *testing.T) {
 
 type testUser struct{}
 
-func (u testUser) GetID() uint      { return 1 }
+func (u testUser) GetID() int64     { return 1 }
 func (u testUser) GetEmail() string { return "test@example.com" }

--- a/logger/doc.go
+++ b/logger/doc.go
@@ -18,11 +18,11 @@ The [TrailsLogger] provides all the logging functionality needed for a trails ap
 It is the implementation of [Logger] returned by the [New] function.
 
 Log messages emitted by [TrailsLogger] are composed of a few parts:
-	- timestamp
-	- log level
-	- call site
-	- message
-	- log context
+  - timestamp
+  - log level
+  - call site
+  - message
+  - log context
 
 Here's an example:
 

--- a/model.go
+++ b/model.go
@@ -12,7 +12,7 @@ import (
 // A Model is the essential data points for primary ID-based models in a trails application,
 // indicating when a record was created, last updated and soft deleted.
 type Model struct {
-	ID        uint        `json:"id"`
+	ID        int64       `json:"id"`
 	CreatedAt time.Time   `json:"createdAt"`
 	UpdatedAt time.Time   `json:"updatedAt"`
 	DeletedAt DeletedTime `json:"deletedAt"`

--- a/ranger/config.go
+++ b/ranger/config.go
@@ -67,7 +67,7 @@ func (Config[U]) defaultUserStore(db postgres.DatabaseService) middleware.UserSt
 		}
 	}
 
-	return func(id uint) (middleware.User, error) {
+	return func(id int64) (middleware.User, error) {
 		var user U
 		err := findByID(&user, id)
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/user.go
+++ b/user.go
@@ -13,7 +13,7 @@ import "github.com/google/uuid"
 type User struct {
 	Model
 	AccessState AccessState `json:"accessState"`
-	AccountID   uint        `json:"accountId"`
+	AccountID   int64       `json:"accountId"`
 	Email       string      `json:"email"`
 	ExternalID  uuid.UUID   `json:"externalId"`
 	Password    []byte      `json:"-"`
@@ -43,4 +43,4 @@ func (u User) HomePath() string {
 	return "/"
 }
 
-func (u User) GetID() uint { return u.ID }
+func (u User) GetID() int64 { return u.ID }


### PR DESCRIPTION
Replaces `uint` with `int64`.

⚠️ Subtle breaking change. Don't hump to the new minor version unless ready to take the plung. May be tough to debug otherwise. But, this change requires updating `User.ID` in a codebase to `int64` - unless it uses `trails.Model` - to keep session stores humming along.