### PR TITLE
[DEV-3407] postgres/postgres: defines Scope

### DIFF
--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -126,5 +126,7 @@ func WipeDB(db *gorm.DB) error {
 //
 // The scope turns into a subquery like so:
 //
-// db.Preload("Members", ActiveUsers()(db)).Where("role = ?", "owner").Find(&owners)
+//	db.Preload("Members", ActiveUsers()(db)).Where("role = ?", "owner").Find(&owners)
+//
+// Cf. [*gorm.DB.Scopes], https://gorm.io/docs/scopes.html
 type Scope func(*gorm.DB) *gorm.DB

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -112,3 +112,19 @@ func WipeDB(db *gorm.DB) error {
 
 	return db.Exec(fmt.Sprintf("TRUNCATE %s CASCADE;", strings.Join(tables, ", "))).Error
 }
+
+// A Scope returns a function that fulfills the interface expected by gorm.Scopes.
+//
+// A Scope can be converted to a subquery by passing in a *gorm.DB instance.
+// For example, given this scope:
+//
+//	func ActiveUsers() Scope {
+//	    return func(dbx *gorm.DB) *gorm.DB {
+//	       return dbx.Where("state = ?", "active")
+//	    }
+//	}
+//
+// The scope turns into a subquery like so:
+//
+// db.Preload("Members", ActiveUsers()(db)).Where("role = ?", "owner").Find(&owners)
+type Scope func(*gorm.DB) *gorm.DB


### PR DESCRIPTION
This formalizes the function that [`gorm.Scopes`](https://github.com/go-gorm/gorm/blob/a9d27293de2267a36fa6c9f8892977d3159cf8ea/chainable_api.go#L376-L380) accepts. This aids DX in small ways:
1. Provides documentation for how to use scopes
2. Simplifies discovering scopes with a grep-able name
3. Simplifies code completion (i.e., `postgres.Scope` instead of `func(db *gorm.DB) *gorm.DB`

In the future, we can imagine `Scope` having helpers attached as methods. By having the type already in place, it'll be less updates.

For how this is used, cf. https://github.com/xy-planning-network/college-try/pull/1837