### PR TITLE
[DEV-3407] enables setting PostgreSQL schema for DB

### DIFF
--- a/postgres/migrate.go
+++ b/postgres/migrate.go
@@ -35,9 +35,9 @@ func (m Migration) execute(db *gorm.DB) error {
 	return nil
 }
 
-func MigrateUp(db *gorm.DB, migrations []Migration) error {
-	// Ensure public schema exists
-	ensurePublicSchema(db)
+func MigrateUp(db *gorm.DB, schema string, migrations []Migration) error {
+	// Ensure schema exists
+	ensureSchema(db, schema)
 
 	// Ensure migrations table exists
 	ensureMigrationsTable(db)
@@ -57,10 +57,10 @@ func MigrateUp(db *gorm.DB, migrations []Migration) error {
 	return nil
 }
 
-func ensurePublicSchema(db *gorm.DB) {
-	err := db.Exec("CREATE SCHEMA IF NOT EXISTS public;").Error
+func ensureSchema(db *gorm.DB, schema string) {
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema)).Error
 	if err != nil {
-		panic(fmt.Sprintf("Error creating public schema. Cannot continue: %s", err))
+		panic(fmt.Sprintf("Error creating %s schema. Cannot continue: %s", schema, err))
 	}
 }
 

--- a/ranger/ranger.go
+++ b/ranger/ranger.go
@@ -151,7 +151,7 @@ func (r *Ranger) Guide() error {
 	// or *postgres.MockDatabaseService,
 	// which we don't need to run migrations against.
 	if db, ok := r.db.(*postgres.DatabaseServiceImpl); ok {
-		if err := postgres.MigrateUp(db.DB, r.migrations); err != nil {
+		if err := postgres.MigrateUp(db.DB, "public", r.migrations); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Moves away from hardcoding `public` in different calls setting up the DB. We can find a more elegant API down the line, but this gets the job done!

For an example: https://github.com/xy-planning-network/college-try/pull/1921